### PR TITLE
added else if statement to handle `grob` object separately in plot_w_set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # teal.widgets 0.1.0.9000
 
-* No changes since last release
+### Bug fixes
+
+* Fixed an edge case bug where zooming in or out from the browser would cause a plot of a `grob` object to not re-render instead displaying a blank white space.
 
 # teal.widgets 0.1.0
 

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -309,6 +309,11 @@ plot_with_settings_srv <- function(id,
       if (plot_type() == "gg" && dblclicking) {
         plot_r() +
           ggplot2::coord_cartesian(xlim = ranges$x, ylim = ranges$y, expand = FALSE)
+      } else if (plot_type() == "grob") {
+        # calling grid.draw on plot_r() is needed;
+        # otherwise the plot will not re-render if the user triggers the zoom in or out feature of the browser.
+        grid::grid.newpage()
+        grid::grid.draw(plot_r())
       } else {
         plot_r()
       }


### PR DESCRIPTION
closes #19 

Steps to recreate bug:

* After app launch, zoom in or out of the RStudio shiny browser. The plot will turn into a blank white space.

Fix:

* grob objects must be drawn via `grid::grid.draw` function.

To test:

```r
library(scda)
library(teal.modules.general)
ADSL <- synthetic_cdisc_data("latest")$adsl

app <- init(
  data = cdisc_data(
    cdisc_dataset("ADSL", ADSL, code = "ADSL <- synthetic_cdisc_data(\"latest\")$adsl"),
    check = TRUE
  ),
  modules = modules(
    tm_g_association(
      ref = data_extract_spec(
        dataname = "ADSL",
        select = select_spec(
          label = "Select variable:",
          choices = variable_choices(
            ADSL,
            c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
          ),
          selected = "RACE",
          fixed = FALSE
        )
      ),
      vars = data_extract_spec(
        dataname = "ADSL",
        select = select_spec(
          label = "Select variables:",
          choices = variable_choices(
            ADSL,
            c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
          ),
          selected = "BMRKR2",
          multiple = TRUE,
          fixed = FALSE
        )
      ),
      ggplot2_args = teal.widgets::ggplot2_args(labs = list(subtitle = "Plot generated by Association Module"))
    )
  )
)

shinyApp(app$ui, app$server)
```