### PR TITLE
feat: made draggable_buckets widgets independent 

### DIFF
--- a/R/draggable_buckets.R
+++ b/R/draggable_buckets.R
@@ -50,6 +50,42 @@ draggable_buckets <- function(input_id, label, elements = character(), buckets) 
   elements_iterator <- new.env(parent = emptyenv())
   elements_iterator$it <- 0
 
+  shiny::tagList(
+    shiny::tags$head(shiny::singleton(
+      shiny::includeScript(system.file("widgets/draggable_buckets.js", package = "teal.widgets"))
+    )),
+    shiny::tags$head(shiny::singleton(
+      shiny::includeCSS(system.file("css/draggable_buckets.css", package = "teal.widgets"))
+    )),
+    shiny::div(
+      shiny::tags$span(label),
+      render_unbucketed_elements(elements = elements, elements_iterator = elements_iterator, widget_id = input_id),
+      render_buckets(buckets = buckets, elements_iterator = elements_iterator, widget_id = input_id),
+      class = "draggableBuckets",
+      id = input_id
+    )
+  )
+}
+
+render_unbucketed_elements <- function(elements, elements_iterator, widget_id) {
+  shiny::tags$div(
+    lapply(elements, function(element) {
+      elements_iterator$it <- elements_iterator$it + 1
+      render_draggable_element(
+        value = element,
+        id = paste0(widget_id, "draggable", elements_iterator$it),
+        widget_id = widget_id
+      )
+    }),
+    id = paste0(widget_id, "elements"),
+    class = c("form-control", "elements"),
+    ondragover = "allowDrop(event)",
+    ondrop = "drop(event)",
+    `data-widget` = widget_id
+  )
+}
+
+render_buckets <- function(buckets, elements_iterator, widget_id) {
   buckets <- `if`(
     is.list(buckets),
     lapply(names(buckets), function(bucket_name) {
@@ -57,38 +93,15 @@ draggable_buckets <- function(input_id, label, elements = character(), buckets) 
         name = bucket_name,
         elements = buckets[[bucket_name]],
         elements_iterator = elements_iterator,
-        input_id = input_id
+        widget_id = widget_id
       )
     }),
-    lapply(buckets, render_bucket)
+    lapply(buckets, render_bucket, widget_id = widget_id, elements_iterator = elements_iterator)
   )
-  shiny::tagList(
-    shiny::tags$head(
-      shiny::singleton(shiny::includeScript(system.file("widgets/draggable_buckets.js", package = "teal.widgets")))
-    ),
-    shiny::tags$head(shiny::singleton(
-      shiny::includeCSS(system.file("css/draggable_buckets.css", package = "teal.widgets"))
-    )),
-    shiny::div(
-      shiny::tags$span(label),
-      shiny::tags$div(
-        lapply(elements, function(element) {
-          elements_iterator$it <- elements_iterator$it + 1
-          render_draggable_element(value = element, id = paste0(input_id, "draggable", elements_iterator$it))
-        }),
-        id = paste0(input_id, "elements"),
-        class = c("form-control", "elements"),
-        ondragover = "allowDrop(event)",
-        ondrop = "drop(event)"
-      ),
-      shiny::tagList(buckets),
-      class = "draggableBuckets",
-      id = input_id
-    )
-  )
+  shiny::tagList(buckets)
 }
 
-render_draggable_element <- function(value, id) {
+render_draggable_element <- function(value, id, widget_id) {
   shiny::tags$div(
     value,
     id = id,
@@ -96,25 +109,32 @@ render_draggable_element <- function(value, id) {
     draggable = "true",
     ondragstart = "drag(event)",
     ondragover = "allowDrop(event)",
-    ondrop = "dropReorder(event)"
+    ondrop = "dropReorder(event)",
+    `data-widget` = widget_id
   )
 }
 
-render_bucket <- function(name, elements = NULL, elements_iterator = NULL, input_id = NULL) {
+render_bucket <- function(name, elements = NULL, elements_iterator = NULL, widget_id = NULL) {
   shiny::tags$div(
     shiny::tags$div(
       paste0(name, ":"),
       class = "bucket-name",
       ondragover = "allowDrop(event)",
-      ondrop = "dropBucketName(event)"
+      ondrop = "dropBucketName(event)",
+      `data-widget` = widget_id
     ),
     lapply(elements, function(element) {
       elements_iterator$it <- elements_iterator$it + 1
-      render_draggable_element(element, id = paste0(input_id, "draggable", elements_iterator$it))
+      render_draggable_element(
+        value = element,
+        id = paste0(widget_id, "draggable", elements_iterator$it),
+        widget_id = widget_id
+      )
     }),
     class = c("form-control", "bucket"),
     ondragover = "allowDrop(event)",
     ondrop = "drop(event)",
-    `data-label` = name
+    `data-label` = name,
+    `data-widget` = widget_id
   )
 }

--- a/inst/css/draggable_buckets.css
+++ b/inst/css/draggable_buckets.css
@@ -9,7 +9,7 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   min-width: 2rem;
-  min-height: 2rem;
+  min-height: 3.75rem;
   margin-top: 2px;
   margin-bottom: 2px;
   height: auto;
@@ -28,7 +28,7 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   min-width: 2rem;
-  min-height: 2rem;
+  min-height: 3.75rem;
   margin-top: 2px;
   margin-bottom: 2px;
   height: auto;

--- a/inst/widgets/draggable_buckets.js
+++ b/inst/widgets/draggable_buckets.js
@@ -12,7 +12,8 @@ const drop = (event) => {
   if (
     data !== null &&
     (event.target.classList.contains("bucket") ||
-      event.target.classList.contains("elements"))
+      event.target.classList.contains("elements")) &&
+    areSameWidget(document.getElementById(data), event.target)
   )
     event.target.appendChild(document.getElementById(data));
 };
@@ -20,7 +21,11 @@ const drop = (event) => {
 const dropReorder = (event) => {
   event.preventDefault();
   const data = event.dataTransfer.getData("element");
-  if (data !== null && event.target.classList.contains("element"))
+  if (
+    data !== null &&
+    event.target.classList.contains("element") &&
+    areSameWidget(document.getElementById(data), event.target)
+  )
     event.target.parentNode.insertBefore(
       document.getElementById(data),
       document.getElementById(event.target.id)
@@ -30,7 +35,11 @@ const dropReorder = (event) => {
 const dropBucketName = (event) => {
   event.preventDefault();
   const data = event.dataTransfer.getData("element");
-  if (data !== null && event.target.classList.contains("bucket-name")) {
+  if (
+    data !== null &&
+    event.target.classList.contains("bucket-name") &&
+    areSameWidget(document.getElementById(data), event.target)
+  ) {
     // needs to be 3 because the name div is surrounded by 2 text div's
     // so draggable elements starts at index 3
     const thirdChild = event.target.nextSibling.nextSibling;
@@ -39,6 +48,13 @@ const dropBucketName = (event) => {
       thirdChild
     );
   }
+};
+
+const areSameWidget = (object1, object2) => {
+  return (
+    object1?.dataset.widget !== undefined &&
+    object1.dataset.widget === object2?.dataset.widget
+  );
 };
 
 // Shiny callbacks


### PR DESCRIPTION
* also refactored the code for better readability
* also tinkered with CSS to avoid resizing of the bucket container when
  no buckets were present in it

Closes https://github.com/insightsengineering/teal.widgets/issues/43

Test with the examples from the docs.