### PR TITLE
Update plot_with_settings.R - dim slot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # teal.widgets 0.1.1.9002
 
+* Added the `dim` slot to the list returned by the `plot_with_settings` module.
+
 ### New features
 * Added a new module - `verbatim_popup`.
 

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -452,7 +452,7 @@ plot_with_settings_srv <- function(id,
           input$width
           input$plot_hover
         }),
-        dim = reactive(c(input$width_in_modal), input$height_in_modal))
+        dim = reactive(c(input$width_in_modal, input$height_in_modal))
       )
     )
   })

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -451,7 +451,8 @@ plot_with_settings_srv <- function(id,
           input$height
           input$width
           input$plot_hover
-        })
+        }),
+        dim = reactive(c(input$width_in_modal), input$height_in_modal))
       )
     )
   })

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -452,7 +452,7 @@ plot_with_settings_srv <- function(id,
           input$width
           input$plot_hover
         }),
-        dim = reactive(c(input$width_in_modal, input$height_in_modal))
+        dim = reactive(c(input$width, input$height))
       )
     )
   })

--- a/inst/js/pinned.js
+++ b/inst/js/pinned.js
@@ -1,6 +1,0 @@
-
-  $(document).ready(function(event) {
-    $(document).on("click", "div.standard_layout_output_panel", function(el) {
-        $(el.target).closest("div.standard_layout_output_panel").toggleClass("affix");
-    })
-  })

--- a/inst/js/pinned.js
+++ b/inst/js/pinned.js
@@ -1,0 +1,6 @@
+
+  $(document).ready(function(event) {
+    $(document).on("click", "div.standard_layout_output_panel", function(el) {
+        $(el.target).closest("div.standard_layout_output_panel").toggleClass("affix");
+    })
+  })


### PR DESCRIPTION
closes #62 

Added the `dim` slot to the list returned by the `plot_with_settings` module.
It will be consumed by e.g. teal.reporter when append_plot is used.