### PR TITLE
Update font awesome icon labels for FA 6

### DIFF
--- a/R/optionalInput.R
+++ b/R/optionalInput.R
@@ -213,8 +213,8 @@ variable_type_icons <- function(var_type) {
   checkmate::assert_character(var_type, any.missing = FALSE)
 
   class_to_icon <- list(
-    numeric = "sort-numeric-up",
-    integer = "sort-numeric-up",
+    numeric = "arrow-up-1-9",
+    integer = "arrow-up-1-9",
     logical = "pause",
     Date = "calendar",
     POSIXct = "calendar",
@@ -222,7 +222,7 @@ variable_type_icons <- function(var_type) {
     factor = "chart-bar",
     character = "keyboard",
     primary_key = "key",
-    unknown = "question-circle"
+    unknown = "circle-question"
   )
   class_to_icon <- lapply(class_to_icon, function(icon_name) toString(icon(icon_name, lib = "font-awesome")))
 

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -40,10 +40,10 @@ plot_with_settings_ui <- function(id) {
       tags$div(
         class = "plot-settings-buttons",
         type_download_ui(ns("downbutton")),
-        actionButton(ns("expand"), label = character(0), icon = icon("fas fa-expand-alt"), class = "btn-sm"),
+        actionButton(ns("expand"), label = character(0), icon = icon("up-right-and-down-left-from-center"), class = "btn-sm"),
         shinyWidgets::dropdownButton(
           circle = FALSE,
-          icon = icon("fas fa-arrows-alt"),
+          icon = icon("maximize"),
           inline = TRUE,
           right = TRUE,
           label = "",

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -347,7 +347,7 @@ plot_with_settings_srv <- function(id,
       grDevices::dev.off()
       if (`if`(!is.null(input$width), input$width, default_slider_width()[1]) < w) {
         helpText(
-          icon("exclamation-triangle"),
+          icon("triangle-exclamation"),
           "Plot might be cut off for small widths."
         )
       }

--- a/R/table_with_settings.R
+++ b/R/table_with_settings.R
@@ -194,7 +194,7 @@ type_download_srv_table <- function(id, table_reactive) {
         if (inherits(catch_warning, "try-error")) {
           helpText(
             class = "error",
-            icon("exclamation-triangle"),
+            icon("triangle-exclamation"),
             "Maximum lines per page includes the reprinted header. Please enter a numeric value or increase the value."
           )
         }


### PR DESCRIPTION
Update font awesome icon labels for FA 6, to avoid warnings like:

```
This Font Awesome icon ('some icon') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```