### PR TITLE
optionalSliderInput - out of range

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 * Fixed bug in `verbatim_popup_srv` where `disabled` argument didn't influence the popup button. 
-* Fixed `optionalSliderInput` validation regarding the possible range.
+* Fixed `optionalSliderInput` validation to remove a warning message in certain cases.
 
 ### New features
 * Added a new module - `verbatim_popup`.

--- a/R/optionalInput.R
+++ b/R/optionalInput.R
@@ -374,11 +374,7 @@ optionalSliderInput <- function(inputId, label, min, max, value, label_help = NU
   is_na_min <- is.na(min)
   is_na_max <- is.na(max)
 
-  hide <- if (is_na_min || is_na_max) {
-    TRUE
-  } else {
-    FALSE
-  }
+  hide <- is_na_min || is_na_max
 
   if (length(value) == 2) {
     value1 <- value[1]

--- a/R/optionalInput.R
+++ b/R/optionalInput.R
@@ -367,9 +367,18 @@ extract_raw_choices <- function(choices, sep) {
 #' @examples
 #' optionalSliderInput("a", "b", 0, 1, 0.2)
 optionalSliderInput <- function(inputId, label, min, max, value, label_help = NULL, ...) { # nolint
-  checkmate::assert_number(min)
-  checkmate::assert_number(max)
+  checkmate::assert_number(min, na.ok = TRUE)
+  checkmate::assert_number(max, na.ok = TRUE)
   checkmate::assert_numeric(value, min.len = 1, max.len = 2, any.missing = FALSE)
+
+  is_na_min <- is.na(min)
+  is_na_max <- is.na(max)
+
+  hide <- if (is_na_min || is_na_max) {
+    TRUE
+  } else {
+    FALSE
+  }
 
   if (length(value) == 2) {
     value1 <- value[1]
@@ -379,14 +388,15 @@ optionalSliderInput <- function(inputId, label, min, max, value, label_help = NU
     value2 <- value
   }
 
-  hide <- if (is.na(min) || is.na(max)) {
+  if (is_na_min) {
     min <- value1 - 1
+  }
+  if (is_na_max) {
     max <- value2 + 1
-    TRUE
-  } else if (min > value1 || max < value2) {
+  }
+
+  if (min > value1 || max < value2) {
     stop("arguments inconsistent: min <= value <= max expected")
-  } else {
-    FALSE
   }
 
   slider <- sliderInput(inputId, label, min, max, value, ...)

--- a/R/optionalInput.R
+++ b/R/optionalInput.R
@@ -369,7 +369,7 @@ extract_raw_choices <- function(choices, sep) {
 optionalSliderInput <- function(inputId, label, min, max, value, label_help = NULL, ...) { # nolint
   checkmate::assert_number(min)
   checkmate::assert_number(max)
-  checkmate::assert_numeric(value, min.len = 1, max.len = 2)
+  checkmate::assert_numeric(value, min.len = 1, max.len = 2, any.missing = FALSE)
 
   if (length(value) == 2) {
     value1 <- value[1]

--- a/tests/testthat/test-optionalInput.R
+++ b/tests/testthat/test-optionalInput.R
@@ -19,3 +19,9 @@ testthat::test_that("optionalSliderInput double value - out of range", {
     "arguments inconsistent: min <= value <= max expected"
   )
 })
+
+testthat::test_that("optionalSliderInput min/max NA", {
+  testthat::expect_error(optionalSliderInput("a", "b", NA, 1, 0.2), NA)
+  testthat::expect_error(optionalSliderInput("a", "b", NA, NA, 0.2), NA)
+  testthat::expect_error(optionalSliderInput("a", "b", 0, 1, 0.2), NA)
+})

--- a/tests/testthat/test-optionalInput.R
+++ b/tests/testthat/test-optionalInput.R
@@ -3,8 +3,10 @@ testthat::test_that("optionalSliderInput single value", {
 })
 
 testthat::test_that("optionalSliderInput single value - out of range", {
-  testthat::expect_error(optionalSliderInput("a", "b", 0, 1, -1),
-                         "arguments inconsistent: min <= value <= max expected")
+  testthat::expect_error(
+    optionalSliderInput("a", "b", 0, 1, -1),
+    "arguments inconsistent: min <= value <= max expected"
+  )
 })
 
 testthat::test_that("optionalSliderInput double value", {
@@ -12,6 +14,8 @@ testthat::test_that("optionalSliderInput double value", {
 })
 
 testthat::test_that("optionalSliderInput double value - out of range", {
-  testthat::expect_error(optionalSliderInput("a", "b", 0, 1, c(-1, 2)),
-                         "arguments inconsistent: min <= value <= max expected")
+  testthat::expect_error(
+    optionalSliderInput("a", "b", 0, 1, c(-1, 2)),
+    "arguments inconsistent: min <= value <= max expected"
+  )
 })


### PR DESCRIPTION
closes #88 

Fixed the  optionalSliderInput conditional which assumed only single value for the slider position.
Another fix are proper values when min and max are NA.