### PR TITLE
add link option to verbatim popup ui

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * `disabled` in `verbatim_popup_srv` is longer triggered when button is hidden.
+* Added `type` argument to `verbatim_popup_ui` which allows the pop-up to be controlled by a `button` or a `link`.
 
 # teal.widgets 0.2.0
 

--- a/R/verbatim_popup.R
+++ b/R/verbatim_popup.R
@@ -6,7 +6,7 @@
 #'
 #' @param id (`character(1)`) the `shiny` id
 #' @param button_label (`character(1)`) the text printed on the button
-#' @param type (`button` or `link`) should `[shiny::actionButton()]` or `[shiny::actionLink()]` be used.
+#' @param type (`character(1)`) specifying whether to use `[shiny::actionButton()]` or `[shiny::actionLink()]`.
 #' @param ... additional arguments to `[shiny::actionButton()]`(or `[shiny::actionLink()]`).
 #'
 #' @return the UI function returns a `shiny.tag.list` object

--- a/man/verbatim_popup.Rd
+++ b/man/verbatim_popup.Rd
@@ -21,7 +21,7 @@ verbatim_popup_srv(
 
 \item{button_label}{(\code{character(1)}) the text printed on the button}
 
-\item{type}{(\code{button} or \code{link}) should \verb{[shiny::actionButton()]} or \verb{[shiny::actionLink()]} be used.}
+\item{type}{(\code{character(1)}) specifying whether to use \verb{[shiny::actionButton()]} or \verb{[shiny::actionLink()]}.}
 
 \item{...}{additional arguments to \verb{[shiny::actionButton()]}(or \verb{[shiny::actionLink()]}).}
 

--- a/man/verbatim_popup.Rd
+++ b/man/verbatim_popup.Rd
@@ -6,7 +6,7 @@
 \alias{verbatim_popup_srv}
 \title{A \code{shiny} module that pops up verbatim text.}
 \usage{
-verbatim_popup_ui(id, button_label, ...)
+verbatim_popup_ui(id, button_label, type = c("button", "link"), ...)
 
 verbatim_popup_srv(
   id,
@@ -21,7 +21,9 @@ verbatim_popup_srv(
 
 \item{button_label}{(\code{character(1)}) the text printed on the button}
 
-\item{...}{additional arguments to \verb{[shiny::actionButton()]}}
+\item{type}{(\code{button} or \code{link}) should \verb{[shiny::actionButton()]} or \verb{[shiny::actionLink()]} be used.}
+
+\item{...}{additional arguments to \verb{[shiny::actionButton()]}(or \verb{[shiny::actionLink()]}).}
 
 \item{verbatim_content}{(\code{character}, \code{expression}, \code{condition} or \code{reactive(1)}
 holding any of the above) the content to show in the popup modal window}

--- a/tests/testthat/test-verbatim_popup.R
+++ b/tests/testthat/test-verbatim_popup.R
@@ -118,5 +118,3 @@ testthat::test_that("verbatim_popup_ui with type 'link' produces a link", {
   ui_char <- as.character(verbatim_popup_ui(id = "test_id", button_label = "Test button label", type = "link"))
   testthat::expect_true(grepl("^<a ", ui_char))
 })
-
-

--- a/tests/testthat/test-verbatim_popup.R
+++ b/tests/testthat/test-verbatim_popup.R
@@ -101,3 +101,22 @@ testthat::test_that("verbatim_popup_ui returns a tag list", {
     inherits(verbatim_popup_ui(id = "test_id", button_label = "Test button label"), "shiny.tag.list")
   )
 })
+
+testthat::test_that("verbatim_popup_ui with type not equal to 'button' or 'link' throws error", {
+  testthat::expect_error(
+    verbatim_popup_ui(id = "test_id", button_label = "Test button label", type = "abc"),
+    "" # match.arg explicitly says in documentation not to test specific error message
+  )
+})
+
+testthat::test_that("verbatim_popup_ui with type 'button' produces a button", {
+  ui_char <- as.character(verbatim_popup_ui(id = "test_id", button_label = "Test button label", type = "button"))
+  testthat::expect_true(grepl("^<button ", ui_char))
+})
+
+testthat::test_that("verbatim_popup_ui with type 'link' produces a link", {
+  ui_char <- as.character(verbatim_popup_ui(id = "test_id", button_label = "Test button label", type = "link"))
+  testthat::expect_true(grepl("^<a ", ui_char))
+})
+
+


### PR DESCRIPTION
See https://github.com/insightsengineering/teal/pull/767 for more details

Allow popup to be a link or button:

Please check "..." arguments to verbatim_popup_ui work :)

![image](https://user-images.githubusercontent.com/15201933/198267866-90b5e5d1-8adf-48c6-8a29-4ffb3ae6e85e.png)


```
library(teal.widgets)

ui <- shiny::fluidPage(
  verbatim_popup_ui("my_id", button_label = "Open popup"),
  verbatim_popup_ui("my_id2", button_label = "Open popup", type = "link")
)

srv <- function(input, output) {
  verbatim_popup_srv(
    "my_id",
    "if (TRUE) { print('Popups are the best') }",
    title = "My custom title",
    style = TRUE
  )
  verbatim_popup_srv(
    "my_id2",
    "if (TRUE) { print('Popups are the best') }",
    title = "My custom title",
    style = TRUE
  )
}

shiny::shinyApp(ui, srv)

```

