### PR TITLE
[UAT] [teal.widgets] Paginate table says lock/unlock instead of on/off #407

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * `disabled` in `verbatim_popup_srv` is longer triggered when button is hidden.
 * Added `type` argument to `verbatim_popup_ui` which allows the pop-up to be controlled by a `button` or a `link`.
 
+### Bug fixes
+
+* Added labels to pagination button in `table_with_settings` and fixed alt text.
+
 # teal.widgets 0.2.0
 
 ### Breaking changes

--- a/R/table_with_settings.R
+++ b/R/table_with_settings.R
@@ -141,7 +141,7 @@ type_download_ui_table <- function(id) {
         condition = paste0("input['", ns("file_format"), "'] != '.csv'"),
         div(
           class = "lock-btn",
-          title = "lock / unlock",
+          title = "on / off",
           shinyWidgets::prettyToggle(
             ns("pagination_switch"),
             value = FALSE,


### PR DESCRIPTION
Closes [this issue](https://github.com/insightsengineering/coredev-tasks/issues/407).

As requested, the alt text has been updated.
Also added explicit text labels.