### PR TITLE
PWS modification of download

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.widgets 0.2.0.9010
 
+### New features
+
+* Added support for downloading base plots.
+
 ### Enhancements
 
 * `disabled` in `verbatim_popup_srv` is longer triggered when button is hidden.
@@ -12,6 +16,7 @@
 ### Miscellaneous
 
 * Added `shinytest2` tests for `plot_with_settings` and `table_with_settings`.
+* Removed the `DRAFT` label on downloaded plots.
 
 # teal.widgets 0.2.0
 

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -252,6 +252,8 @@ plot_with_settings_srv <- function(id,
         "trel"
       } else if (inherits(plot_r(), "grob")) {
         "grob"
+      } else if (inherits(plot_r(), c("NULL", "histogram")) && !inherits(plot_r, "reactive")) {
+        "base"
       } else {
         "other"
       }
@@ -586,16 +588,19 @@ get_plot_dpi <- function() {
 #' @keywords internal
 #'
 print_plot <- function(plot, plot_type) {
-  if (plot_type() == "grob") {
-    grid::grid.draw(plot())
-  } else if (plot_type() == "other") {
-    graphics::plot.new()
-    graphics::text(
-      x = graphics::grconvertX(0.5, from = "npc"),
-      y = graphics::grconvertY(0.5, from = "npc"),
-      labels = "This plot graphic type is not yet supported to download"
-    )
-  } else {
-    print(plot())
-  }
+  switch(plot_type(),
+         "grob" = grid::grid.draw(plot()),
+         "other" = {
+           graphics::plot.new()
+           graphics::text(
+             x = graphics::grconvertX(0.5, from = "npc"),
+             y = graphics::grconvertY(0.5, from = "npc"),
+             labels = "This plot graphic type is not yet supported to download"
+           )
+         },
+         "base" = {
+           plot()
+         },
+         print(plot())
+         )
 }

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -68,8 +68,9 @@ plot_with_settings_ui <- function(id) {
 #' @export
 #'
 #' @inheritParams shiny::moduleServer
-#' @param plot_r (`reactive`)\cr
-#'  reactive expression to draw a plot.
+#' @param plot_r (`reactive` or `function`)\cr
+#'  reactive expression or a simple `function` to draw a plot.
+#'  A simple `function` is needed e.g. for base plots like `plot(1)` as the output can not be catch by shiny.
 #' @param height (`numeric`, optional)\cr
 #'  vector with three elements c(VAL, MIN, MAX), where VAL is the starting value of the slider in
 #'  the main and modal plot display. The value in the modal display is taken from the value of the

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -200,7 +200,10 @@ plot_with_settings_srv <- function(id,
                                    dblclicking = FALSE,
                                    hovering = FALSE,
                                    graph_align = "left") {
-  checkmate::assert_class(plot_r, c("reactive", "function"))
+  checkmate::assert(
+    checkmate::check_class(plot_r, "reactive"),
+    checkmate::check_class(plot_r, "function")
+  )
   checkmate::assert_numeric(height, min.len = 1, any.missing = FALSE)
 
   checkmate::assert_numeric(height, len = 3, any.missing = FALSE, finite = TRUE)
@@ -241,6 +244,7 @@ plot_with_settings_srv <- function(id,
       })
     }
 
+    plot_input_type <- inherits(plot_r, "function")
     plot_type <- reactive({
       if (inherits(plot_r(), "ggplot")) {
         "gg"
@@ -365,6 +369,7 @@ plot_with_settings_srv <- function(id,
       id = "downbutton",
       plot_reactive = plot_r,
       plot_type = plot_type,
+      plot_input_type = plot_input_type,
       plot_w = reactive(`if`(!is.null(input$width), input$width, default_slider_width()[1])),
       default_w = default_w,
       plot_h = reactive(`if`(!is.null(input$height), input$height, height[1])),
@@ -428,6 +433,7 @@ plot_with_settings_srv <- function(id,
       id = "modal_downbutton",
       plot_reactive = plot_r,
       plot_type = plot_type,
+      plot_input_type = plot_input_type,
       plot_w = reactive(input$width_in_modal),
       default_w = default_w,
       plot_h = reactive(input$height_in_modal),
@@ -492,7 +498,7 @@ type_download_ui <- function(id) {
   )
 }
 
-type_download_srv <- function(id, plot_reactive, plot_type, plot_w, default_w, plot_h, default_h) {
+type_download_srv <- function(id, plot_reactive, plot_type, plot_input_type, plot_w, default_w, plot_h, default_h) {
   moduleServer(
     id,
     function(input, output, session) {
@@ -511,7 +517,7 @@ type_download_srv <- function(id, plot_reactive, plot_type, plot_w, default_w, p
             svg = grDevices::svg(file, width / get_plot_dpi(), height / get_plot_dpi())
           )
 
-          print_plot(plot_reactive(), plot_type())
+          print_plot(plot_reactive, plot_type, plot_input_type)
 
           grDevices::dev.off()
         }
@@ -577,42 +583,33 @@ get_plot_dpi <- function() {
 #'  reactive expression to draw a plot
 #' @param plot_type (`reactive`)\cr
 #'  reactive plot type (`gg`, `trel`, `grob`, `other`)
+#' @param plot_input_type (`logical`)\cr
+#'  type of plot_type input given
 #'
 #' @return Nothing returned, the plot is printed.
 #' @keywords internal
 #'
-print_plot <- function(plot, plot_type) {
-  if (plot_type == "other") {
-    graphics::plot.new()
-    graphics::text(
-      x = graphics::grconvertX(0.5, from = "npc"),
-      y = graphics::grconvertY(0.5, from = "npc"),
-      labels = "This plot graphic type is not yet supported to download"
-    )
+print_plot <- function(plot, plot_type, plot_input_type) {
+  return_plot <- function(plot, plot_type) {
+    if (plot_type() == "grob") {
+      grid::grid.draw(plot())
+    } else {
+      print(plot())
+    }
+  }
+
+  if (plot_input_type) {
+    return_plot(plot, plot_type)
   } else {
-    g <- plot
-    wm <- grid::grid.text(
-      "DRAFT",
-      draw = FALSE,
-      rot = -45,
-      gp = grid::gpar(
-        alpha = 0.3,
-        fontface = "bold",
-        cex = 3
+    if (plot_type == "other") {
+      graphics::plot.new()
+      graphics::text(
+        x = graphics::grconvertX(0.5, from = "npc"),
+        y = graphics::grconvertY(0.5, from = "npc"),
+        labels = "This plot graphic type is not yet supported to download"
       )
-    )
-    g_fin <- grid::gTree(
-      children = grid::gList(
-        if (plot_type == "grob") {
-          g
-        } else if (plot_type == "gg") {
-          ggplot2::ggplotGrob(g)
-        } else if (plot_type == "trel") {
-          grid::grid.grabExpr(print(g), warn = 0, wrap.grobs = TRUE)
-        },
-        wm
-      )
-    )
-    grid::grid.draw(g_fin)
+    } else {
+      return_plot(plot, plot_type)
+    }
   }
 }

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -150,6 +150,7 @@ plot_with_settings_ui <- function(id) {
 #'         plot(1)
 #'       }
 #'     }
+#'
 #'     plot_with_settings_srv(
 #'       id = "plot_with_settings",
 #'       plot_r = plot_r,

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -589,18 +589,18 @@ get_plot_dpi <- function() {
 #'
 print_plot <- function(plot, plot_type) {
   switch(plot_type(),
-         "grob" = grid::grid.draw(plot()),
-         "other" = {
-           graphics::plot.new()
-           graphics::text(
-             x = graphics::grconvertX(0.5, from = "npc"),
-             y = graphics::grconvertY(0.5, from = "npc"),
-             labels = "This plot graphic type is not yet supported to download"
-           )
-         },
-         "base" = {
-           plot()
-         },
-         print(plot())
-         )
+    "grob" = grid::grid.draw(plot()),
+    "other" = {
+      graphics::plot.new()
+      graphics::text(
+        x = graphics::grconvertX(0.5, from = "npc"),
+        y = graphics::grconvertY(0.5, from = "npc"),
+        labels = "This plot graphic type is not yet supported to download"
+      )
+    },
+    "base" = {
+      plot()
+    },
+    print(plot())
+  )
 }

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -202,7 +202,8 @@ plot_with_settings_srv <- function(id,
                                    hovering = FALSE,
                                    graph_align = "left") {
   checkmate::assert(
-    checkmate::check_class(plot_r, "function")
+    checkmate::check_class(plot_r, "function"),
+    checkmate::check_class(plot_r, "reactive") # to be sure
   )
   checkmate::assert_numeric(height, min.len = 1, any.missing = FALSE)
 

--- a/man/plot_with_settings_srv.Rd
+++ b/man/plot_with_settings_srv.Rd
@@ -23,7 +23,7 @@ UI function.}
 
 \item{plot_r}{(\code{reactive} or \code{function})\cr
 reactive expression or a simple \code{function} to draw a plot.
-A simple \code{function} is needed e.g. for base plots like \code{plot(1)} as the output can not be catch by shiny.}
+A simple \code{function} is needed e.g. for base plots like \code{plot(1)} as the output can not be caught when downloading.}
 
 \item{height}{(\code{numeric}, optional)\cr
 vector with three elements c(VAL, MIN, MAX), where VAL is the starting value of the slider in
@@ -72,6 +72,7 @@ If an invalid value is set then the default value is used and a warning is outpu
 }
 \examples{
 \dontrun{
+# Example using a reactive as input to plot_r
 library(shiny)
 shinyApp(
   ui = fluidPage(
@@ -84,6 +85,36 @@ shinyApp(
       ggplot2::qplot(x = 1, y = 1)
     })
 
+    plot_with_settings_srv(
+      id = "plot_with_settings",
+      plot_r = plot_r,
+      height = c(400, 100, 1200),
+      width = c(500, 250, 750)
+    )
+  }
+)
+
+# Example using a function as input to plot_r
+shinyApp(
+  ui = fluidPage(
+    radioButtons("download_option", "Select the Option", list("ggplot", "trellis", "grob", "base")),
+    plot_with_settings_ui(
+      id = "plot_with_settings"
+    )
+  ),
+  server = function(input, output, session) {
+    plot_r <- function() {
+      if (input$download_option == "ggplot") {
+        ggplot2::qplot(1)
+      } else if (input$download_option == "trellis") {
+        densityplot(1)
+      } else if (input$download_option == "grob") {
+        tr_plot <- densityplot(1)
+        ggplotify::as.grob(tr_plot)
+      } else if (input$download_option == "base") {
+        plot(1)
+      }
+    }
     plot_with_settings_srv(
       id = "plot_with_settings",
       plot_r = plot_r,

--- a/man/plot_with_settings_srv.Rd
+++ b/man/plot_with_settings_srv.Rd
@@ -115,6 +115,7 @@ shinyApp(
         plot(1)
       }
     }
+
     plot_with_settings_srv(
       id = "plot_with_settings",
       plot_r = plot_r,

--- a/man/plot_with_settings_srv.Rd
+++ b/man/plot_with_settings_srv.Rd
@@ -21,8 +21,9 @@ plot_with_settings_srv(
 \item{id}{An ID string that corresponds with the ID used to call the module's
 UI function.}
 
-\item{plot_r}{(\code{reactive})\cr
-reactive expression to draw a plot.}
+\item{plot_r}{(\code{reactive} or \code{function})\cr
+reactive expression or a simple \code{function} to draw a plot.
+A simple \code{function} is needed e.g. for base plots like \code{plot(1)} as the output can not be catch by shiny.}
 
 \item{height}{(\code{numeric}, optional)\cr
 vector with three elements c(VAL, MIN, MAX), where VAL is the starting value of the slider in

--- a/man/print_plot.Rd
+++ b/man/print_plot.Rd
@@ -4,7 +4,7 @@
 \alias{print_plot}
 \title{Print plot for download functionality}
 \usage{
-print_plot(plot, plot_type)
+print_plot(plot, plot_type, plot_input_type)
 }
 \arguments{
 \item{plot}{(\code{reactive})\cr
@@ -12,6 +12,9 @@ reactive expression to draw a plot}
 
 \item{plot_type}{(\code{reactive})\cr
 reactive plot type (\code{gg}, \code{trel}, \code{grob}, \code{other})}
+
+\item{plot_input_type}{(\code{logical})\cr
+type of plot_type input given}
 }
 \value{
 Nothing returned, the plot is printed.

--- a/man/print_plot.Rd
+++ b/man/print_plot.Rd
@@ -4,7 +4,7 @@
 \alias{print_plot}
 \title{Print plot for download functionality}
 \usage{
-print_plot(plot, plot_type, plot_input_type)
+print_plot(plot, plot_type)
 }
 \arguments{
 \item{plot}{(\code{reactive})\cr
@@ -12,9 +12,6 @@ reactive expression to draw a plot}
 
 \item{plot_type}{(\code{reactive})\cr
 reactive plot type (\code{gg}, \code{trel}, \code{grob}, \code{other})}
-
-\item{plot_input_type}{(\code{logical})\cr
-type of plot_type input given}
 }
 \value{
 Nothing returned, the plot is printed.


### PR DESCRIPTION
closes #48 

The aim of this PR was to simplify the downloading to reduce the testing steps. Nevertheless, the request to download `base` graphics was not straight forward (which explains why we did not do it before) and the user can now download a `base` plot in case they provide a `function` instead of a `reactive`. If this solution is too complex and not needed for now, we can revert the changes to remove `DRAFT`  and simplify `print_plot` only.

Test with:
```
library(shiny)
data("mtcars")
shinyApp(
  ui = fluidPage(
    radioButtons("download_option", "Select the Option", list("ggplot", "trellis", "grob", "base")),
    plot_with_settings_ui(
      id = "plot_with_settings"
    )
  ),
  server = function(input, output, session) {
#replace reactive here with function
    plot_r <- reactive({
      if (input$download_option == "ggplot") {
        ggplot2::qplot(1, 2)
      } else if (input$download_option == "trellis") {
        densityplot(~mpg,
                    data = mtcars, 
          main = "Density Plot",
          xlab = "Miles per Gallon"
        )
      } else if (input$download_option == "grob") {
        tr_plot <- densityplot(~mpg,
                               data = mtcars, 
          main = "Density Plot",
          xlab = "Miles per Gallon"
        )
        ggplotify::as.grob(tr_plot)
      } else if (input$download_option == "base") {
        plot(1, 2)
      }
    })
    plot_with_settings_srv(
      id = "plot_with_settings",
      plot_r = plot_r,
      height = c(400, 100, 1200),
      width = c(500, 250, 750)
    )
  }
)

```