### PR TITLE
77 remove teal.code from staged.dependencies.yml

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -7,9 +7,6 @@ upstream_repos:
     repo: insightsengineering/rtables
     host: https://github.com
 downstream_repos:
-  insightsengineering/teal.code:
-    repo: insightsengineering/teal.code
-    host: https://github.com
   insightsengineering/teal.slice:
     repo: insightsengineering/teal.slice
     host: https://github.com


### PR DESCRIPTION
A follow-up after https://github.com/insightsengineering/teal.code/pull/121 where we removed teal.widgets from teal.code