### PR TITLE
Fix invisible grob plot on popup

### DIFF
--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -364,11 +364,6 @@ plot_with_settings_srv <- function(id,
       if (plot_type() == "gg" && dblclicking) {
         plot_r() +
           ggplot2::coord_cartesian(xlim = ranges$x, ylim = ranges$y, expand = FALSE)
-      } else if (plot_type() == "grob") {
-        # calling grid.draw on plot_r() is needed;
-        # otherwise the plot will not re-render if the user triggers the zoom in or out feature of the browser.
-        grid::grid.newpage()
-        grid::grid.draw(plot_r())
       } else {
         plot_r()
       }
@@ -377,14 +372,14 @@ plot_with_settings_srv <- function(id,
     p_height <- reactive(`if`(!is.null(input$height), input$height, height[1]))
     p_width <- reactive(`if`(!is.null(input$width), input$width, default_slider_width()[1]))
     output$plot_main <- renderPlot(
-      plot_reactive(),
+      plot(plot_reactive()),
       res = get_plot_dpi(),
       height = p_height,
       width = p_width
     )
 
     output$plot_modal <- renderPlot(
-      plot_reactive(),
+      plot(plot_reactive()),
       res = get_plot_dpi(),
       height = reactive(input$height_in_modal),
       width = reactive(input$width_in_modal)

--- a/tests/testthat/test-plot_with_settings.R
+++ b/tests/testthat/test-plot_with_settings.R
@@ -432,7 +432,7 @@ testthat::test_that("plot_with_settings_srv set dimensions and download a png fi
 })
 
 testthat::test_that("plot_with_settings_srv expand no error", {
-  plot_with_settings_args[["plot_r"]] <- function() plot(1)
+  plot_with_settings_args[["plot_r"]] <- function() 1
   shiny::testServer(
     teal.widgets:::plot_with_settings_srv,
     args = plot_with_settings_args,
@@ -444,7 +444,7 @@ testthat::test_that("plot_with_settings_srv expand no error", {
 })
 
 testthat::test_that("plot_with_settings_srv set dimensions and download a png file from modal", {
-  plot_with_settings_args[["plot_r"]] <- function() plot(1)
+  plot_with_settings_args[["plot_r"]] <- function() 1
   shiny::testServer(
     teal.widgets:::plot_with_settings_srv,
     args = plot_with_settings_args,
@@ -466,7 +466,7 @@ testthat::test_that("plot_with_settings_srv set dimensions and download a png fi
 })
 
 testthat::test_that("plot_with_settings_srv returns the click ggplot2 functionalities metadata", {
-  plot_with_settings_args$plot_r <- function() plot(1)
+  plot_with_settings_args$plot_r <- function() 1
   shiny::testServer(
     teal.widgets:::plot_with_settings_srv,
     args = plot_with_settings_args,


### PR DESCRIPTION
Closes #171 

The `grid::grid.draw()` is already handled by the [shiny::renderPlot](https://github.com/rstudio/shiny/blob/69188fef2244670afb8eb4203b03c3b9b3893caa/R/render-plot.R#L338) so we just need to let shiny do its thing.
