### PR TITLE
Move selected icon in dropbdowns to left side

### DIFF
--- a/inst/css/picker_input.css
+++ b/inst/css/picker_input.css
@@ -10,3 +10,17 @@
   width: 100%;
   overflow: auto;
 }
+
+/* Place check-mark on left side of text */
+.bootstrap-select.show-tick .dropdown-menu li.selected a span.check-mark {
+  position: relative;
+  visibility: visible;
+  top: 0;
+  right: 5px;
+  opacity: 1;
+}
+
+.bootstrap-select.show-tick .dropdown-menu li a span.check-mark {
+  visibility: hidden;
+  display: inline-block;
+}

--- a/inst/css/picker_input.css
+++ b/inst/css/picker_input.css
@@ -23,4 +23,5 @@
 .bootstrap-select.show-tick .dropdown-menu li a span.check-mark {
   visibility: hidden;
   display: inline-block;
+  min-width: 0.8em;
 }


### PR DESCRIPTION
# Pull Request

Fixes https://github.com/insightsengineering/teal.modules.clinical/issues/802

#### Changes description

* Global CSS/Styling rule for all dropdowns created via `pickerInput`, such as `teal.widgets::optionalSelectInput`

note: the CSS was created via discussion of the feature, a PR was an easy convertion

#### 2 column layout

![image](https://github.com/insightsengineering/teal.widgets/assets/211358/fe5bc9b9-4dfd-4068-929b-4f0eebcebb09)

![image](https://github.com/insightsengineering/teal.widgets/assets/211358/81d0e227-dbe9-45dd-8766-fa1716639c94)

![image](https://github.com/insightsengineering/teal.widgets/assets/211358/f7d16692-028c-4bdc-8012-347014d52dbd)

#### 1 column layout

![image](https://github.com/insightsengineering/teal.widgets/assets/211358/b2bfcb57-bdd6-4cc2-ac76-2328fde0e99c)

