### PR TITLE
430 use `expect_no_error` in tests instead of `expect_error(, NA)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     png,
     shinytest2 (>= 0.2.0),
     shinyvalidate,
-    testthat (>= 3.0.4),
+    testthat (>= 3.1.5),
     withr (>= 2.1.0)
 VignetteBuilder:
     knitr

--- a/tests/testthat/test-ggplot2_args.R
+++ b/tests/testthat/test-ggplot2_args.R
@@ -1,10 +1,10 @@
 testthat::test_that("ggplot2_args, no error with empty inputs", {
-  testthat::expect_error(ggplot2_args(), NA)
-  testthat::expect_error(ggplot2_args(labs = list(), theme = list()), NA)
-  testthat::expect_error(ggplot2_args(labs = list()), NA)
-  testthat::expect_error(ggplot2_args(theme = list()), NA)
-  testthat::expect_error(ggplot2_args(list()), NA)
-  testthat::expect_error(ggplot2_args(list(), list()), NA)
+  testthat::expect_no_error(ggplot2_args())
+  testthat::expect_no_error(ggplot2_args(labs = list(), theme = list()))
+  testthat::expect_no_error(ggplot2_args(labs = list()))
+  testthat::expect_no_error(ggplot2_args(theme = list()))
+  testthat::expect_no_error(ggplot2_args(list()))
+  testthat::expect_no_error(ggplot2_args(list(), list()))
 })
 
 testthat::test_that("ggplot2_args function returns object of ggplot2_args and list classes", {
@@ -12,12 +12,11 @@ testthat::test_that("ggplot2_args function returns object of ggplot2_args and li
 })
 
 testthat::test_that("ggplot2_args accepts named lists for arguments labs and theme", {
-  testthat::expect_error(
+  testthat::expect_no_error(
     ggplot2_args(
       labs = list(title = "SOME TITLE"),
       theme = list(axis.title = ggplot2::element_blank())
-    ),
-    NA
+    )
   )
 })
 
@@ -27,7 +26,7 @@ testthat::test_that("ggplot2_args throws error when argument name is not valid."
 })
 
 testthat::test_that("resolve_ggplot2_args accepts empty inputs", {
-  testthat::expect_error(resolve_ggplot2_args(), NA)
+  testthat::expect_no_error(resolve_ggplot2_args())
 })
 
 testthat::test_that("resolve_ggplot2_args support NULL inputs", {

--- a/tests/testthat/test-ggplot2_args.R
+++ b/tests/testthat/test-ggplot2_args.R
@@ -53,8 +53,8 @@ testthat::test_that("resolve_ggplot2_args function returns object of ggplot2_arg
 })
 
 testthat::test_that("parse_ggplot2_args accepts empty inputs", {
-  testthat::expect_error(parse_ggplot2_args(resolve_ggplot2_args()), NA)
-  testthat::expect_error(parse_ggplot2_args(), NA)
+  testthat::expect_no_error(parse_ggplot2_args(resolve_ggplot2_args()))
+  testthat::expect_no_error(parse_ggplot2_args())
 })
 
 testthat::test_that("parse_ggplot2_args throws error with empty list", {

--- a/tests/testthat/test-optionalInput.R
+++ b/tests/testthat/test-optionalInput.R
@@ -1,5 +1,5 @@
 testthat::test_that("optionalSliderInput single value", {
-  testthat::expect_error(optionalSliderInput("a", "b", 0, 1, 0.2), NA)
+  testthat::expect_no_error(optionalSliderInput("a", "b", 0, 1, 0.2))
 })
 
 testthat::test_that("optionalSliderInput single value - out of range", {
@@ -10,7 +10,7 @@ testthat::test_that("optionalSliderInput single value - out of range", {
 })
 
 testthat::test_that("optionalSliderInput double value", {
-  testthat::expect_error(optionalSliderInput("a", "b", 0, 1, c(0.2, 0.8)), NA)
+  testthat::expect_no_error(optionalSliderInput("a", "b", 0, 1, c(0.2, 0.8)))
 })
 
 testthat::test_that("optionalSliderInput double value - out of range", {

--- a/tests/testthat/test-optionalInput.R
+++ b/tests/testthat/test-optionalInput.R
@@ -21,7 +21,7 @@ testthat::test_that("optionalSliderInput double value - out of range", {
 })
 
 testthat::test_that("optionalSliderInput min/max NA", {
-  testthat::expect_error(optionalSliderInput("a", "b", NA, 1, 0.2), NA)
-  testthat::expect_error(optionalSliderInput("a", "b", NA, NA, 0.2), NA)
-  testthat::expect_error(optionalSliderInput("a", "b", 0, 1, 0.2), NA)
+  testthat::expect_no_error(optionalSliderInput("a", "b", NA, 1, 0.2))
+  testthat::expect_no_error(optionalSliderInput("a", "b", NA, NA, 0.2))
+  testthat::expect_no_error(optionalSliderInput("a", "b", 0, 1, 0.2))
 })

--- a/tests/testthat/test-plot_with_settings.R
+++ b/tests/testthat/test-plot_with_settings.R
@@ -171,12 +171,11 @@ testthat::test_that("clean_brushedPoints returns error with wrong input", {
 })
 
 testthat::test_that("clean_brushedPoints returns a data frame with minimal correct input", {
-  testthat::expect_error(
+  testthat::expect_no_error(
     clean_brushedPoints(
       data.frame(AGE = 1, BMRKR1 = 4),
       brush[c("direction", "range", "xmin", "xmax", "ymin", "ymax", "mapping")]
-    ),
-    NA
+    )
   )
 })
 

--- a/tests/testthat/test-table_args.R
+++ b/tests/testthat/test-table_args.R
@@ -14,7 +14,7 @@ testthat::test_that("basic_table_args function returns list of the basic_table_a
 })
 
 testthat::test_that("basic_table_args rtables arguments validation, correct input", {
-  testthat::expect_error(basic_table_args(title = "SOME TITLE"), NA)
+  testthat::expect_no_error(basic_table_args(title = "SOME TITLE"))
 })
 
 testthat::test_that("basic_table_args rtables arguments validation, incorrect input", {
@@ -22,7 +22,7 @@ testthat::test_that("basic_table_args rtables arguments validation, incorrect in
 })
 
 testthat::test_that("resolve_basic_table_args returns empty basic_table_args with empty input", {
-  testthat::expect_error(resolve_basic_table_args(), NA)
+  testthat::expect_no_error(resolve_basic_table_args())
 })
 
 testthat::test_that("resolve_basic_table_args error with empty list, as need a basic_table_args class", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -6,7 +6,7 @@ testthat::test_that("get_bs_version", {
 ggplot_obj <- ggplot2::ggplot(data = iris, ggplot2::aes(x = Sepal.Length, y = Sepal.Width)) +
   ggplot2::geom_point()
 
-test_that("apply_plot_modifications, Modify ggplot object with dblclicking enabled", {
+testthat::test_that("apply_plot_modifications, Modify ggplot object with dblclicking enabled", {
   modified_ggplot <- apply_plot_modifications(
     plot_obj = ggplot_obj,
     plot_type = "gg",
@@ -16,7 +16,7 @@ test_that("apply_plot_modifications, Modify ggplot object with dblclicking enabl
   testthat::expect_true(identical(class(modified_ggplot), class(ggplot_obj)))
 })
 
-test_that("apply_plot_modifications, Modify ggplot object with dblclicking disabled", {
+testthat::test_that("apply_plot_modifications, Modify ggplot object with dblclicking disabled", {
   modified_ggplot <- apply_plot_modifications(
     plot_obj = ggplot_obj,
     plot_type = "gg",
@@ -26,7 +26,7 @@ test_that("apply_plot_modifications, Modify ggplot object with dblclicking disab
   testthat::expect_true(identical(class(modified_ggplot), class(ggplot_obj)))
 })
 
-test_that("apply_plot_modifications, Modify grob object", {
+testthat::test_that("apply_plot_modifications, Modify grob object", {
   grob_obj <- grid::rectGrob()
   modified_grob <- apply_plot_modifications(
     plot_obj = grob_obj,
@@ -37,7 +37,7 @@ test_that("apply_plot_modifications, Modify grob object", {
   testthat::expect_null(modified_grob)
 })
 
-test_that("apply_plot_modifications, Do not modify plot object", {
+testthat::test_that("apply_plot_modifications, Do not modify plot object", {
   unchanged_plot <- apply_plot_modifications(
     plot_obj = ggplot_obj,
     plot_type = "other_type",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -13,7 +13,7 @@ test_that("apply_plot_modifications, Modify ggplot object with dblclicking enabl
     dblclicking = TRUE,
     ranges = list(x = c(4, 7), y = c(2, 4))
   )
-  expect_true(identical(class(modified_ggplot), class(ggplot_obj)))
+  testthat::expect_true(identical(class(modified_ggplot), class(ggplot_obj)))
 })
 
 test_that("apply_plot_modifications, Modify ggplot object with dblclicking disabled", {
@@ -23,7 +23,7 @@ test_that("apply_plot_modifications, Modify ggplot object with dblclicking disab
     dblclicking = FALSE,
     ranges = list(x = c(4, 7), y = c(2, 4))
   )
-  expect_true(identical(class(modified_ggplot), class(ggplot_obj)))
+  testthat::expect_true(identical(class(modified_ggplot), class(ggplot_obj)))
 })
 
 test_that("apply_plot_modifications, Modify grob object", {
@@ -34,7 +34,7 @@ test_that("apply_plot_modifications, Modify grob object", {
     dblclicking = TRUE,
     ranges = list(x = c(0, 1), y = c(0, 1))
   )
-  expect_null(modified_grob)
+  testthat::expect_null(modified_grob)
 })
 
 test_that("apply_plot_modifications, Do not modify plot object", {
@@ -44,5 +44,5 @@ test_that("apply_plot_modifications, Do not modify plot object", {
     dblclicking = TRUE,
     ranges = list(x = c(4, 7), y = c(2, 4))
   )
-  expect_true(identical(unchanged_plot, ggplot_obj))
+  testthat::expect_true(identical(unchanged_plot, ggplot_obj))
 })


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/430