### PR TITLE
233 remove duplicated buttons from `verbatim_popup`

### DIFF
--- a/R/verbatim_popup.R
+++ b/R/verbatim_popup.R
@@ -118,21 +118,12 @@ button_click_observer <- function(click_event,
         shiny::modalDialog(
           shiny::tagList(
             include_css_files(pattern = "verbatim_popup"),
-            shiny::tags$div(
-              class = "mb-4",
-              shiny::actionButton(
-                paste0(copy_button_id, 1),
-                "Copy to Clipboard",
-                onclick = paste0("copyToClipboard('", copied_area_id, "')")
-              ),
-              shiny::modalButton("Dismiss")
-            ),
             shiny::tags$pre(id = copied_area_id, modal_content()),
           ),
           title = modal_title,
           footer = shiny::tagList(
             shiny::actionButton(
-              paste0(copy_button_id, 2),
+              copy_button_id,
               "Copy to Clipboard",
               onclick = paste0("copyToClipboard('", copied_area_id, "')")
             ),


### PR DESCRIPTION
Closes #233 

This PR removes duplicated buttons for `verbatim_popup` that is used by `Show R Code` and `Show Session Info`. Not `verbatim_popup` looks like this

<img width="646" alt="image" src="https://github.com/insightsengineering/teal.widgets/assets/133694481/77228430-60a9-4ddc-8c01-02c1e5ea102a">


```r
library(shiny)
ui <- fluidPage(verbatim_popup_ui("my_id", button_label = "Open popup"))
srv <- function(input, output) {
  verbatim_popup_srv(
    "my_id",
    "if (TRUE) { print('Popups are the best') }",
    title = "My custom title",
    style = TRUE
  )
}
if (interactive()) shinyApp(ui, srv)
```

And also `Show R Code` and `Show Session Info` modal do not contain duplicated `Copy to Clipboard` and `Dismiss` buttons.

<img width="437" alt="image" src="https://github.com/insightsengineering/teal.widgets/assets/133694481/239f7956-d333-4f1a-9aae-e2a290722a09">
<img width="319" alt="image" src="https://github.com/insightsengineering/teal.widgets/assets/133694481/d8f4cd61-07b3-4923-adb6-a2f2bd88cbf0">
