### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Depends:
 Imports:
     bslib,
     checkmate (>= 2.1.0),
-    ggplot2 (>= 3.4.0),
+    ggplot2 (>= 3.4.3),
     graphics,
     grDevices,
     htmltools (>= 0.5.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
     magrittr (>= 1.5),
     png,
     rmarkdown (>= 2.23),
-    rvest (>= 1.0.4),
+    rvest (>= 1.0.3),
     shinytest2 (>= 0.2.0),
     shinyvalidate,
     testthat (>= 3.1.5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
     magrittr (>= 1.5),
     png,
     rmarkdown (>= 2.23),
-    rvest,
+    rvest (>= 1.0.4),
     shinytest2 (>= 0.2.0),
     shinyvalidate,
     testthat (>= 3.1.5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Suggests:
     lattice (>= 0.18-4),
     magrittr (>= 1.5),
     png,
+    rmarkdown (>= 2.23),
     rvest,
     shinytest2 (>= 0.2.0),
     shinyvalidate,
@@ -52,7 +53,8 @@ Config/Needs/verdepcheck: rstudio/bslib, mllg/checkmate,
     tidyverse/ggplot2, rstudio/htmltools, r-lib/lifecycle,
     insightsengineering/rtables, rstudio/shiny, daattali/shinyjs,
     dreamRs/shinyWidgets, r-lib/styler, rstudio/DT, yihui/knitr,
-    deepayan/lattice, tidyverse/magrittr, cran/png, rstudio/shinytest2,
+    deepayan/lattice, tidyverse/magrittr, cran/png, 
+    tidyverse/rvest, rstudio/rmarkdown, rstudio/shinytest2,
     rstudio/shinyvalidate, r-lib/testthat, r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.