### PR TITLE
Update custom-basic-table-arguments.Rmd (#1)

### DIFF
--- a/vignettes/custom-basic-table-arguments.Rmd
+++ b/vignettes/custom-basic-table-arguments.Rmd
@@ -17,23 +17,23 @@ creator in the server function, which has the lowest priority.
 
 The implementation should consist of 5 steps:
 
-1. Adding `basic_table_args` argument to the `tm_t_*` function and then its server function.
+1. Add the `basic_table_args` arguments to the `tm_t_*` function and then its server function.
 The default should be set to
 the `basic_table_args()` function for a single plot.
 and  `list(default = basic_table_args())` multi-table modules.
-2. Adding a validation (e.g. `stopifnot` or `checkmate`) of the `basic_table_args` argument to the `tm_*` function.
+2. Add validation (e.g. `stopifnot` or `checkmate`) for the `basic_table_args` arguments to the `tm_*` function.
 The validation is more complex for multi-table modules, where the `ggplot2_args` could be a `list`.
 The module creator has to provide a list of plots names, which should be validated at this step and added to the `param` 
 field in `roxygen2`. For multi-table modules the step 
 `if (is_basic_table_args) basic_table_args <- list(default = basic_table_args)` is recommended.
-3. Aggregating and reducing all `basic_table_args` sources with `resolve_basic_table_args()`.
-4. Usage of the `parse_basic_table_args()` function which will aggregate and reduce all inputs
+3. Aggregate and reduce all `basic_table_args` sources with `resolve_basic_table_args()`.
+4. Use the `parse_basic_table_args()` function which will aggregate and reduce all inputs
 to one expression.
-5. Adding the created expression to the chunk with a table.
+5. Add the created expression to the chunk with a table.
 
 The `parse_basic_table_args()` function picks the first non NULL value for each argument, checking in order:
 
-1. `basic_table_args` argument provided by the end user.
+1. `basic_table_args` arguments provided by the end user.
 For multi-table case, per table (`basic_table_args_table`) and then default (`basic_table_args_default`) setup.
 2. Global R variable (`options`), `teal.basic_table_args`.
 3. `basic_table_args_developer` which is a developer setup, lowest priority.


### PR DESCRIPTION
Reading over this vignette `basic-table-args` was using singular instead of plural form which was misleading. I also fixed other syntax errors with incorrect tense usage for a list, as when writing instructions you do not usually use continuous tense.
