### PR TITLE
decouple `teal.widgets` from `teal` in plot resizing

### DIFF
--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -12,7 +12,7 @@ plot_with_settings_ui <- function(id) {
       tags$script(
         sprintf(
           'establishPlotResizing("%s", "%s", "%s");',
-          ns("plot_out_main"), # graph parent id
+          ns("plot_main"), # graph parent id
           ns("flex_width"), # session input$ variable name
           ns("plot_modal_width") # session input$ variable name
         )

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -8,25 +8,12 @@ plot_with_settings_ui <- function(id) {
 
   tagList(
     shiny::singleton(tags$head(
+      shiny::includeScript(system.file("js", "resize_plot.js", package = "teal.widgets")),
       tags$script(
-        # nolint start
         sprintf(
-          '$(document).on("shiny:connected", function(e) {
-            Shiny.onInputChange("%s", document.getElementById("%s").clientWidth);
-            Shiny.onInputChange("%s", 0.87*window.innerWidth);
-            //based on modal CSS property, also accounting for margins
-          });
-          $(window).resize(function(e) {
-            Shiny.onInputChange("%s", document.getElementById("%s").clientWidth);
-            Shiny.onInputChange("%s", 0.87*window.innerWidth);
-            //based on modal CSS property, also accounting for margins
-          });',
-          # nolint end
-          ns("flex_width"), # session input$ variable name
+          'establishPlotResizing("%s", "%s", "%s");',
           ns("plot_out_main"), # graph parent id
-          ns("plot_modal_width"), # session input$ variable name
           ns("flex_width"), # session input$ variable name
-          ns("plot_out_main"), # graph parent id
           ns("plot_modal_width") # session input$ variable name
         )
       )

--- a/inst/css/plot_with_settings.css
+++ b/inst/css/plot_with_settings.css
@@ -33,6 +33,7 @@
 
 .plot_out_container div:nth-child(1) {
   margin-top: 30px;
+  overflow-x: hidden;
 }
 
 .plot-modal .modal .modal-dialog .modal-content .modal-body .plot-modal-sliders {

--- a/inst/js/resize_plot.js
+++ b/inst/js/resize_plot.js
@@ -1,4 +1,5 @@
-//
+// Function that registers resize observer for particular parent elements.
+// Arguments are namespaced ids of DOM elements.
 var establishPlotResizing = function (
   plot_out,
   flex_width,

--- a/inst/js/resize_plot.js
+++ b/inst/js/resize_plot.js
@@ -1,0 +1,24 @@
+//
+var establishPlotResizing = function (
+  plot_out_main,
+  flex_width,
+  plot_modal_width) {
+
+  // Create resize observer to trigger shiny actions when plot container is resized.
+  var plotObserver = new ResizeObserver(function () {
+    Shiny.onInputChange(flex_width, document.getElementById(plot_out_main).clientWidth);
+    Shiny.onInputChange(plot_modal_width, 0.87 * window.innerWidth);
+    //based on modal CSS property, also accounting for margins
+  });
+
+  // Create mutation observer to delay activation of resize observer.
+  // Activating observer before the target element exists is impossible.
+  var plotNoticer = new MutationObserver(function () {
+    const plotContainer = document.getElementById(plot_out_main);
+    if (plotContainer === null) return;
+    plotObserver.observe(plotContainer, { box: "border-box" } );
+    plotNoticer.disconnect();
+  });
+
+  plotNoticer.observe(document, { subtree: true, childList: true });
+};

--- a/inst/js/resize_plot.js
+++ b/inst/js/resize_plot.js
@@ -1,12 +1,12 @@
 //
 var establishPlotResizing = function (
-  plot_out_main,
+  plot_out,
   flex_width,
   plot_modal_width) {
 
   // Create resize observer to trigger shiny actions when plot container is resized.
   var plotObserver = new ResizeObserver(function () {
-    Shiny.onInputChange(flex_width, document.getElementById(plot_out_main).clientWidth);
+    Shiny.onInputChange(flex_width, document.getElementById(plot_out).clientWidth);
     Shiny.onInputChange(plot_modal_width, 0.87 * window.innerWidth);
     //based on modal CSS property, also accounting for margins
   });
@@ -14,7 +14,7 @@ var establishPlotResizing = function (
   // Create mutation observer to delay activation of resize observer.
   // Activating observer before the target element exists is impossible.
   var plotNoticer = new MutationObserver(function () {
-    const plotContainer = document.getElementById(plot_out_main);
+    const plotContainer = document.getElementById(plot_out);
     if (plotContainer === null) return;
     plotObserver.observe(plotContainer, { box: "border-box" } );
     plotNoticer.disconnect();


### PR DESCRIPTION
Alternative to #248 
Also fixes #249 
Accompanied by https://github.com/insightsengineering/teal/pull/1261

Changed the way that plot rerendering is triggered to fill the container element.
Resizing is still done by sending messages to `shiny` with 
```
    Shiny.onInputChange(flex_width, document.getElementById(plot_out).clientWidth);
    Shiny.onInputChange(plot_modal_width, 0.87 * window.innerWidth);
```
However, the messages are not sent in response to events registered with `$(window).on("resize")`, but rather by a `MutationObserver` object. The callback was being registered in `teal.widgets` but triggered in `teal`, by running `$(".teal_primary_col").trigger("resize")`. Now the resizing behavior is contained to `teal.widgets`.

The same callback was being registered on `shiny:connected` - this is removed.

Also set `overflow-x` property on the plot container to avoid it sticking out of the container before resizing kicks in.

