### PR TITLE
Fix verdepcheck

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -19,7 +19,7 @@ jobs:
       GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
     with:
       strategy: ${{ matrix.test-strategy }}
-      extra-deps: "R.utils (> 2.9.2)"
+      extra-deps: "R.utils (> 2.12.3)"
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
   branch-cleanup:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -19,6 +19,7 @@ jobs:
       GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
     with:
       strategy: ${{ matrix.test-strategy }}
+      extra-deps: "R.utils (> 2.9.2)"
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
   branch-cleanup:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -19,7 +19,7 @@ jobs:
       GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
     with:
       strategy: ${{ matrix.test-strategy }}
-      extra-deps: "R.utils (> 2.12.3)"
+      extra-deps: "R.utils (>= 2.12.3)"
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
   branch-cleanup:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,4 +61,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2


### PR DESCRIPTION
`v2.12.3` is the earliest for which we have a binary available. Anything earlier fails to build from source as reported [here](https://github.com/HenrikBengtsson/R.utils/issues/150)