### PR TITLE
Fix failing `Dependencies Test - max`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Config/Needs/verdepcheck: rstudio/bslib, mllg/checkmate,
     dreamRs/shinyWidgets, r-lib/styler, rstudio/DT, yihui/knitr,
     deepayan/lattice, tidyverse/magrittr, cran/png, tidyverse/rvest,
     rstudio/rmarkdown, rstudio/shinytest2, rstudio/shinyvalidate,
-    r-lib/testthat, r-lib/withr
+    r-lib/testthat, r-lib/withr, insightsengineering/formatters
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
Fixing the failed scheduled pipeline caused by not installing the latest `formatters` by adding the package to `Config/Needs/verdepcheck`:
https://github.com/insightsengineering/teal.widgets/actions/runs/12532246429/job/34950774578#step:9:424