### PR TITLE
recompute live-search in updateoptionalselectinput

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 # teal.widgets 0.4.3.9001
 
 ### Breaking changes
-
 * `panel_group()` and `panel_item()` are deprecated. Please use the `bslib::accordion()` and `bslib::accordion_panel()` instead.
 
+### Bug fixes
+* Recompute the `live-search` option value dynamically in `updateOptionalSelectInput` (#291)
 
 # teal.widgets 0.4.3
 

--- a/R/optionalInput.R
+++ b/R/optionalInput.R
@@ -302,7 +302,10 @@ updateOptionalSelectInput <- function(session, # nolint
     label = label,
     selected = as.character(raw_selected),
     choices = raw_choices,
-    choicesOpt = picker_options(choices)
+    choicesOpt = picker_options(choices),
+    options = list(
+      `live-search` = ifelse(length(raw_choices) > 10, TRUE, FALSE)
+    )
   )
 
   invisible(NULL)


### PR DESCRIPTION
Fixes #291 

* Recompute the option value for `live-search` in updateOptionalSelectInput`. This is to anticipate choices being resolved in delayed data scenario.
* Update NEWS.

<details>

<summary>Code for testing</summary>

```r
library(teal.modules.clinical)

tdm <- teal_data_module(
  ui = function(id) {},
  server = function(id) {
    moduleServer(id, function(input, output, session) {
      reactive({
        data <- cdisc_data(
          ADSL = tmc_ex_adsl
        )
      })
    })
  }
)

app <- init(
  data = tdm,
  modules = modules(
    tm_t_summary(
      label = "Demographic Table",
      dataname = "ADSL",
      arm_var = choices_selected(c("ARM", "ARMCD"), "ARM"),
      add_total = TRUE,
      summarize_vars = choices_selected(
        variable_choices("ADSL"),
        c("SEX", "RACE")
      ),
      useNA = "ifany"
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```

</details>