### PR TITLE
Update shinytest2 for widgets

### DIFF
--- a/tests/testthat/test-plot_with_settings_ui.R
+++ b/tests/testthat/test-plot_with_settings_ui.R
@@ -71,7 +71,7 @@ click_download_popup <- "// Select the element with the popover
 get_active_module_pws_output <- function(app_driver, pws, attr) {
   app_driver$get_html("html") %>%
     rvest::read_html() %>%
-    rvest::html_nodes(sprintf("#plot_with_settings-%s > img", pws)) %>%
+    rvest::html_elements(sprintf("#plot_with_settings-%s > img", pws)) %>%
     rvest::html_attr(attr)
 }
 
@@ -149,13 +149,13 @@ testthat::test_that(
 
     testthat::expect_equal(
       download_button %>%
-        rvest::html_node("i") %>%
+        rvest::html_element("i") %>%
         rvest::html_attr("class"),
       "fas fa-download"
     )
     testthat::expect_equal(
       download_button %>%
-        rvest::html_node("i") %>%
+        rvest::html_element("i") %>%
         rvest::html_attr("aria-label"),
       "download icon"
     )

--- a/tests/testthat/test-plot_with_settings_ui.R
+++ b/tests/testthat/test-plot_with_settings_ui.R
@@ -5,7 +5,6 @@
 #' @keywords internal
 #'
 app_driver_pws <- function() {
-  testthat::skip("chromium")
   shiny::shinyApp(
     ui = bslib::page_fluid(
       shiny::actionButton("button", "Show/Hide"),
@@ -56,7 +55,7 @@ click_resize_popup <- "document.querySelector(
 ).click()"
 
 # JS code to click the expand button popup.
-click_expand_popup <- "document.querySelector('.teal-widgets.settings-buttons .expand-button i').click()"
+click_expand_popup <- "document.querySelector('#plot_with_settings-plot-with-settings > bslib-tooltip > button').click()"
 
 # JS code to click the download button popup inside the expanded modal.
 click_expand_download_popup <- "document.querySelectorAll(
@@ -81,7 +80,6 @@ testthat::test_that("plot_with_settings_ui returns `shiny.tag`", {
 testthat::test_that(
   "e2e: teal.widgets::plot_with_settings: initializes with a plot and the settings buttons",
   {
-    testthat::skip("chromium")
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_pws(),
@@ -104,7 +102,7 @@ testthat::test_that(
   "e2e: teal.widgets::plot_with_settings: buttons have proper FA icons and two of them are dropdowns",
   {
     skip_if_too_deep(5)
-    testthat::skip("chromium")
+
     app_driver <- shinytest2::AppDriver$new(
       app_driver_pws(),
       name = "pws",
@@ -164,7 +162,6 @@ testthat::test_that(
   "e2e: teal.widgets::plot_with_settings: the click on the expand button opens a modal
   plot height, plot width, plot, download dropdown and dismiss button",
   {
-    testthat::skip("chromium")
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_pws(),
@@ -175,18 +172,15 @@ testthat::test_that(
     )
     app_driver$wait_for_idle(timeout = default_idle_timeout)
 
-    testthat::expect_false(is_visible("#plot_with_settings-height_in_modal", app_driver))
-    testthat::expect_false(is_visible("#plot_with_settings-width_in_modal", app_driver))
-    testthat::expect_false(is_visible("#plot_with_settings-modal_downbutton-downl", app_driver))
+    testthat::expect_false(is_visible("#plot_with_settings-plot-with-settings", app_driver))
+    testthat::expect_false(is_visible("#plot_with_settings-plot-with-settings > div > div > div.teal-widgets.settings-buttons > bslib-tooltip.download-button", app_driver))
+    testthat::expect_false(is_visible("#plot_with_settings-expbut", app_driver))
 
-    app_driver$run_js(click_expand_popup)
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
-
-    testthat::expect_true(is_visible("#plot_with_settings-height_in_modal", app_driver))
-    testthat::expect_true(is_visible("#plot_with_settings-width_in_modal", app_driver))
-
+    app_driver$run_js(click_expand_popup, timeout = default_idle_timeout)
+    testthat::expect_true(is_visible("#bslib-full-screen-overlay", app_driver))
+    app_driver$view()
     testthat::expect_identical(
-      app_driver$get_value(input = "plot_with_settings-height_in_modal"),
+      app_driver$get_value(input = "#plot_with_settings-plot-with-settings"),
       400L
     )
     testthat::expect_identical(
@@ -211,7 +205,6 @@ testthat::test_that(
 testthat::test_that(
   "e2e: teal.widgets::plot_with_settings: the click on the download button in expand modal opens a download dropdown",
   {
-    testthat::skip("chromium")
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_pws(),
@@ -255,7 +248,6 @@ testthat::test_that(
   "e2e: teal.widgets::plot_with_settings: the click on the resize button opens a dropdown menu
   plot height, plot width, plot, download dropdown and dismiss button",
   {
-    testthat::skip("chromium")
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_pws(),
@@ -299,7 +291,6 @@ testthat::test_that(
   "e2e: teal.widgets::plot_with_settings: it is possible to set height and width for the plot
   on the third button dropdown menu without errors",
   {
-    testthat::skip("chromium")
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_pws(),
@@ -321,7 +312,6 @@ testthat::test_that(
 testthat::test_that(
   "e2e teal.widgets::plot_with_settings: clicking download+download button downloads image in a specified format",
   {
-    testthat::skip("chromium")
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_pws(),
@@ -341,7 +331,6 @@ testthat::test_that(
 )
 
 testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be resized", {
-  testthat::skip("chromium")
   skip_if_too_deep(5)
   app_driver <- shinytest2::AppDriver$new(
     app_driver_pws(),
@@ -389,7 +378,6 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
 })
 
 testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be downloaded", {
-  testthat::skip("chromium")
   skip_if_too_deep(5)
   app_driver <- shinytest2::AppDriver$new(
     app_driver_pws(),
@@ -411,7 +399,6 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
 })
 
 testthat::test_that("e2e teal.widgets::plot_with_settings: main image can be resized", {
-  testthat::skip("chromium")
   skip_if_too_deep(5)
   app_driver <- shinytest2::AppDriver$new(
     app_driver_pws(),

--- a/tests/testthat/test-plot_with_settings_ui.R
+++ b/tests/testthat/test-plot_with_settings_ui.R
@@ -340,33 +340,35 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
   app_driver$wait_for_idle(timeout = default_idle_timeout)
 
   plot_before <- get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "src")
-
-  testthat::expect_equal(
-    get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "width"),
-    "500"
+  values <- app_driver$get_values()
+  testthat::expect_equal(values$output$`plot_with_settings-plot_main`$width,
+    500L
   )
 
   testthat::expect_equal(
-    get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "height"),
-    "400"
+    values$output$`plot_with_settings-plot_main`$height,
+    400L
   )
-
-  app_driver$set_inputs(`plot_with_settings-height_in_modal` = 1000)
-  app_driver$set_inputs(`plot_with_settings-width_in_modal` = 350)
+  app_driver$run_js(click_resize_popup)
   app_driver$wait_for_idle(timeout = default_idle_timeout)
 
-  testthat::expect_equal(
-    get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "width"),
-    "350"
+  app_driver$set_inputs(`plot_with_settings-height` = 1000)
+  app_driver$set_inputs(`plot_with_settings-width` = 350)
+  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  values_resized <- app_driver$get_values()
+
+  testthat::expect_equal(values_resized$output$`plot_with_settings-plot_main`$width,
+                         350L
   )
 
   testthat::expect_equal(
-    get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "height"),
-    "1000"
+    values_resized$output$`plot_with_settings-plot_main`$height,
+    1000L
   )
 
   testthat::expect_false(
-    identical(plot_before, get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "src"))
+    identical(values$output$`plot_with_settings-plot_main`$src,
+              values_resized$output$`plot_with_settings-plot_main`$src)
   )
 
   app_driver$stop()
@@ -384,10 +386,10 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
   app_driver$run_js(click_expand_popup)
   app_driver$wait_for_idle(timeout = default_idle_timeout)
 
-  app_driver$run_js(click_expand_download_popup)
+  app_driver$run_js(click_download_popup)
   app_driver$wait_for_idle(timeout = default_idle_timeout)
 
-  filename <- app_driver$get_download("plot_with_settings-modal_downbutton-data_download")
+  filename <- app_driver$get_download("plot_with_settings-downbutton-data_download")
   testthat::expect_match(filename, "png$", fixed = FALSE)
 
   app_driver$stop()
@@ -436,27 +438,3 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: main image can be res
 
   app_driver$stop()
 })
-
-
-
-app$set_inputs(`plot_with_settings-plot_click` = character(0), allow_no_input_binding_ = TRUE)
-app$set_inputs(`plot_with_settings-plot_dblclick` = character(0), allow_no_input_binding_ = TRUE)
-app$set_inputs(`plot_with_settings-plot_hover` = character(0), allow_no_input_binding_ = TRUE)
-app$set_inputs(`plot_with_settings-plot_brush` = character(0), allow_no_input_binding_ = TRUE)
-# Update output value
-app$set_window_size(width = 3139, height = 1271)
-app$set_inputs(`plot_with_settings-expbut` = TRUE)
-app$set_window_size(width = 3139, height = 1271)
-# Update output value
-app$set_inputs(`plot_with_settings-width_resize_switch` = FALSE)
-app$set_inputs(`plot_with_settings-height` = 400)
-app$set_inputs(`plot_with_settings-width` = 500)
-# Update output value
-app$set_window_size(width = 3139, height = 1271)
-app$set_inputs(`plot_with_settings-height` = 646)
-# Update output value
-app$set_window_size(width = 3139, height = 1271)
-app$set_inputs(`plot_with_settings-height` = 365)
-# Update output value
-app$set_window_size(width = 3139, height = 1271)
-app$expect_values()

--- a/tests/testthat/test-table_with_settings_ui.R
+++ b/tests/testthat/test-table_with_settings_ui.R
@@ -55,7 +55,7 @@ testthat::test_that("table_with_settings_ui returns `shiny.tag`", {
 testthat::test_that(
   "e2e: teal.widgets::table_with_settings is initialized with 2 buttons and a table",
   {
-    
+
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -77,7 +77,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: the click on the download button opens a download menu
   with file type, file name and download button",
   {
-    
+
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -123,13 +123,13 @@ testthat::test_that(
 
     testthat::expect_equal(
       download_button %>%
-        rvest::html_node("i") %>%
+        rvest::html_element("i") %>%
         rvest::html_attr("class"),
       "fas fa-download"
     )
     testthat::expect_equal(
       download_button %>%
-        rvest::html_node("i") %>%
+        rvest::html_element("i") %>%
         rvest::html_attr("aria-label"),
       "download icon"
     )
@@ -142,7 +142,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: check pagination appearance for .txt and disappearance for .csv
   for the first button",
   {
-    
+
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -170,7 +170,7 @@ testthat::test_that(
 testthat::test_that(
   "e2e: teal.widgets::table_with_settings: the click on expand button opens a modal with a table",
   {
-    
+
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -205,7 +205,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: clicking download in an expand modal opens dropdown menu with dwnl settings,
   such as: file type, file name, pagination",
   {
-    
+
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -251,13 +251,13 @@ testthat::test_that(
 
     testthat::expect_equal(
       download_button %>%
-        rvest::html_node("i") %>%
+        rvest::html_element("i") %>%
         rvest::html_attr("class"),
       "fas fa-download"
     )
     testthat::expect_equal(
       download_button %>%
-        rvest::html_node("i") %>%
+        rvest::html_element("i") %>%
         rvest::html_attr("aria-label"),
       "download icon"
     )
@@ -271,7 +271,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: check pagination appearance for .txt and disappearance for .csv
   for the modal on the second button",
   {
-    
+
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -296,7 +296,7 @@ testthat::test_that(
 testthat::test_that(
   "e2e teal.widgets::table_with_settings: clicking download+download button downloads table in a specified format",
   {
-    
+
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -320,7 +320,7 @@ testthat::test_that(
 )
 
 testthat::test_that("e2e teal.widgets::table_with_settings: expanded table can be downloaded", {
-  
+
   skip_if_too_deep(5)
   app_driver <- shinytest2::AppDriver$new(
     app_driver_tws(),

--- a/tests/testthat/test-table_with_settings_ui.R
+++ b/tests/testthat/test-table_with_settings_ui.R
@@ -55,7 +55,7 @@ testthat::test_that("table_with_settings_ui returns `shiny.tag`", {
 testthat::test_that(
   "e2e: teal.widgets::table_with_settings is initialized with 2 buttons and a table",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -77,7 +77,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: the click on the download button opens a download menu
   with file type, file name and download button",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -142,7 +142,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: check pagination appearance for .txt and disappearance for .csv
   for the first button",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -170,7 +170,7 @@ testthat::test_that(
 testthat::test_that(
   "e2e: teal.widgets::table_with_settings: the click on expand button opens a modal with a table",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -205,7 +205,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: clicking download in an expand modal opens dropdown menu with dwnl settings,
   such as: file type, file name, pagination",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -271,7 +271,7 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings: check pagination appearance for .txt and disappearance for .csv
   for the modal on the second button",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -296,7 +296,7 @@ testthat::test_that(
 testthat::test_that(
   "e2e teal.widgets::table_with_settings: clicking download+download button downloads table in a specified format",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
@@ -320,7 +320,7 @@ testthat::test_that(
 )
 
 testthat::test_that("e2e teal.widgets::table_with_settings: expanded table can be downloaded", {
-  testthat::skip("chromium")
+  
   skip_if_too_deep(5)
   app_driver <- shinytest2::AppDriver$new(
     app_driver_tws(),

--- a/tests/testthat/test-verbatim_popup_ui.R
+++ b/tests/testthat/test-verbatim_popup_ui.R
@@ -30,7 +30,7 @@ testthat::test_that("verbatim_popup_ui returns `shiny.tag.list`", {
 testthat::test_that(
   "e2e: teal.widgets::verbatim_popup is initialized with a button that opens a modal with a verbatim text",
   {
-    testthat::skip("chromium")
+    
     skip_if_too_deep(5)
     ui_popup_button_label <- "Open me"
     modal_title <- "Verbatim popup title"


### PR DESCRIPTION
# Pull Request

Fixes #296

While working on the tests I changed `rvest::html_nodes` to `rvest::html_element`. 
The former was deprecated in rvest 1.0.0 some time ago. 

The issue list 8 widgets but I only found 3 that have ui/server. 

- [ ] `plot_with_settings()`: Missing testing scrollbar functionality
- [x] `table_with_settings()`
- [x] `verbatim_popup()`
- [ ] `get_dt_rows()`: No previous tests.
- [ ] `optionalSelectInput()`/`updateOptionalSelectInput()`: No previous tests
- [ ] `draggable_buckets()`: no scrollbar, no previous tests.
- [ ] `nested_closeable_modal()`: No previous tests
- [ ]  `optionalSliderInputValMinMax()`: one of the examples isn't displayed: 

<details><summary>Details</summary>
<p>

The app is open but no slider is shown
```r
ui <- bslib::page_fluid(
    shinyjs::useShinyjs(),
    optionalSliderInputValMinMax("a1", "b1", 1)
)
if (interactive()) {
    shiny::shinyApp(ui, function(input, output) {})
}
```

</p>
</details> 	
