### PR TITLE
Use input_switch

### DIFF
--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -347,14 +347,10 @@ plot_with_settings_srv <- function(id,
           round = TRUE
         ),
         tags$b("Plot width"),
-        shinyWidgets::switchInput(
-          inputId = ns("width_resize_switch"),
-          onLabel = "ON",
-          offLabel = "OFF",
-          label = "Auto width",
-          value = `if`(is.null(width), TRUE, FALSE),
-          size = "mini",
-          labelWidth = "80px"
+        bslib::input_switch(
+          id = ns("width_resize_switch"),
+          label = "Automatic",
+          value = `if`(is.null(width), TRUE, FALSE)
         ),
         optionalSliderInputValMinMax(
           inputId = ns("width"),

--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -347,10 +347,14 @@ plot_with_settings_srv <- function(id,
           round = TRUE
         ),
         tags$b("Plot width"),
-        bslib::input_switch(
-          id = ns("width_resize_switch"),
-          label = "Automatic",
-          value = `if`(is.null(width), TRUE, FALSE)
+        shinyWidgets::switchInput(
+          inputId = ns("width_resize_switch"),
+          onLabel = "ON",
+          offLabel = "OFF",
+          label = "Auto width",
+          value = `if`(is.null(width), TRUE, FALSE),
+          size = "mini",
+          labelWidth = "80px"
         ),
         optionalSliderInputValMinMax(
           inputId = ns("width"),


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes https://github.com/insightsengineering/nestdevs-tasks/issues/111

I changed the label to Automatic, but maybe I should use auto as the text right above already says "Plot width":

![image](https://github.com/user-attachments/assets/e59cb433-61bd-438a-a4ab-43aa98bd9833)

Depending on the order of merging shinytest2 test might need to be adapted on this or the PR: https://github.com/insightsengineering/teal.widgets/pull/298. 