### PR TITLE
fix scheduled jobs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rvest (>= 1.0.3),
     shinytest2 (>= 0.2.0),
     shinyvalidate,
-    testthat (>= 3.2.0),
+    testthat (>= 3.2.3),
     withr (>= 2.1.0)
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rvest (>= 1.0.3),
     shinytest2 (>= 0.2.0),
     shinyvalidate,
-    testthat (>= 3.2.3),
+    testthat (>= 3.2.0),
     withr (>= 2.1.0)
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: teal.widgets
 Title: 'shiny' Widgets for 'teal' Applications
-Version: 0.4.3.9004
-Date: 2025-06-10
+Version: 0.4.3.9005
+Date: 2025-06-13
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),
     person("Pawel", "Rucki", , "pawel.rucki@roche.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/insightsengineering/teal.widgets/issues
 Depends:
     R (>= 3.6)
 Imports:
-    bslib,
+    bslib (>= 0.8.0),
     checkmate (>= 2.1.0),
     ggplot2 (>= 3.4.3),
     graphics,
@@ -32,7 +32,7 @@ Imports:
     methods,
     rtables (>= 0.6.6),
     shiny (>= 1.6.0),
-    shinyjs,
+    shinyjs (>= 2.1.0),
     shinyWidgets (>= 0.5.1),
     styler (>= 1.2.0)
 Suggests:
@@ -45,7 +45,7 @@ Suggests:
     rvest (>= 1.0.3),
     shinytest2 (>= 0.2.0),
     shinyvalidate,
-    testthat (>= 3.1.5),
+    testthat (>= 3.2.3),
     withr (>= 2.1.0)
 VignetteBuilder:
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.widgets 0.4.3.9004
+# teal.widgets 0.4.3.9005
 
 ### Breaking changes
 * `panel_group()` and `panel_item()` are deprecated. Please use the `bslib::accordion()` and `bslib::accordion_panel()` instead.

--- a/tests/testthat/test-ggplot2_args.R
+++ b/tests/testthat/test-ggplot2_args.R
@@ -188,44 +188,36 @@ testthat::test_that("parse_ggplot2_args, deparse needed to expand ggplot2 object
     )
   )
 
-  testthat::expect_true(!identical(
-    parse_element,
-    list(theme = quote(ggplot2::theme(axis.text = list())))
-  ))
-
-  testthat::expect_true(identical(
-    deparse(parse_element$theme, 140),
-    deparse(
-      quote(ggplot2::theme(axis.text = structure(list(), class = c("element_blank", "element")))),
-      140
-    )
-  ))
+  p <- ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt)) + ggplot2::geom_point()
+  p_with_theme <- p + eval(parse_element$theme)
+  testthat::expect_true(inherits(p_with_theme$theme, "theme"))
+  testthat::expect_true("axis.text" %in% names(p_with_theme$theme))
+  testthat::expect_true(inherits(p_with_theme$theme$axis.text, "element_blank"))
 })
 
 testthat::test_that(
   "resolve_ggplot2_args priorotizes input in the order: user_plot, user_default, teal.ggplot2_args and module_plot",
   code = {
-    testthat::expect_identical(
-      withr::with_options(list(teal.ggplot2_args = ggplot2_args(labs = list(title = "ENV_TITLE"))), {
-        resolve_ggplot2_args(
-          user_plot = ggplot2_args(labs = list(y = "USER_YLAB_DIRECT")),
-          user_default = ggplot2_args(labs = list(x = "USER_XLAB_DEFAULT", y = "USER_YLAB_DEFAULT")),
-          module_plot = ggplot2_args(
-            labs = list(subtitle = "DEVELOPER_SUBTITLE", x = "USER_XLAB_DEV"),
-            theme = list(axis.text = ggplot2::element_blank())
-          )
+    result <- withr::with_options(list(teal.ggplot2_args = ggplot2_args(labs = list(title = "ENV_TITLE"))), {
+      resolve_ggplot2_args(
+        user_plot = ggplot2_args(labs = list(y = "USER_YLAB_DIRECT")),
+        user_default = ggplot2_args(labs = list(x = "USER_XLAB_DEFAULT", y = "USER_YLAB_DEFAULT")),
+        module_plot = ggplot2_args(
+          labs = list(subtitle = "DEVELOPER_SUBTITLE", x = "USER_XLAB_DEV"),
+          theme = list(axis.text = ggplot2::element_blank())
         )
-      }),
-      ggplot2_args(
-        labs = list(
-          y = "USER_YLAB_DIRECT",
-          x = "USER_XLAB_DEFAULT",
-          title = "ENV_TITLE",
-          subtitle = "DEVELOPER_SUBTITLE"
-        ),
-        theme = list(axis.text = structure(list(), class = c("element_blank", "element")))
+      )
+    })
+    testthat::expect_identical(
+      result$labs,
+      list(
+        y = "USER_YLAB_DIRECT",
+        x = "USER_XLAB_DEFAULT",
+        title = "ENV_TITLE",
+        subtitle = "DEVELOPER_SUBTITLE"
       )
     )
+    testthat::expect_true(inherits(result$theme$axis.text, "element_blank"))
   }
 )
 
@@ -248,7 +240,6 @@ testthat::test_that(
         ggtheme = "gray"
       )
     })
-
     testthat::expect_identical(
       parsed_all$labs,
       quote(ggplot2::labs(
@@ -256,17 +247,14 @@ testthat::test_that(
         title = "ENV_TITLE", subtitle = "DEVELOPER_SUBTITLE"
       ))
     )
-
     testthat::expect_identical(
       parsed_all$ggtheme,
       quote(ggplot2::theme_gray())
     )
-
-    # testthat::expect_identical automatically deparse quote for a comparison
-    # Because of element_blank we need to compare it to expanded version
-    testthat::expect_identical(
-      deparse(parsed_all$theme, 500),
-      'ggplot2::theme(axis.text = structure(list(), class = c("element_blank", "element")))'
-    )
+    p <- ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt)) + ggplot2::geom_point()
+    p_with_theme <- p + eval(parsed_all$theme)
+    testthat::expect_true(inherits(p_with_theme$theme, "theme"))
+    testthat::expect_true("axis.text" %in% names(p_with_theme$theme))
+    testthat::expect_true(inherits(p_with_theme$theme$axis.text, "element_blank"))
   }
 )

--- a/tests/testthat/test-ggplot2_args.R
+++ b/tests/testthat/test-ggplot2_args.R
@@ -203,14 +203,12 @@ testthat::test_that("parse_ggplot2_args, deparse needed to expand ggplot2 object
     ))
   } else {
     p <- ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt)) +
-    ggplot2::geom_point()
-  p_with_theme <- p + eval(parse_element$theme)
-  testthat::expect_true(inherits(p_with_theme$theme, "theme"))
-  testthat::expect_true("axis.text" %in% names(p_with_theme$theme))
-  testthat::expect_true(inherits(p_with_theme$theme$axis.text, "element_blank"))
+      ggplot2::geom_point()
+    p_with_theme <- p + eval(parse_element$theme)
+    testthat::expect_true(inherits(p_with_theme$theme, "theme"))
+    testthat::expect_true("axis.text" %in% names(p_with_theme$theme))
+    testthat::expect_true(inherits(p_with_theme$theme$axis.text, "element_blank"))
   }
-  
-
 })
 
 testthat::test_that(
@@ -295,11 +293,11 @@ testthat::test_that(
       )
     } else {
       p <- ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt)) +
-      ggplot2::geom_point()
-    p_with_theme <- p + eval(parsed_all$theme)
-    testthat::expect_true(inherits(p_with_theme$theme, "theme"))
-    testthat::expect_true("axis.text" %in% names(p_with_theme$theme))
-    testthat::expect_true(inherits(p_with_theme$theme$axis.text, "element_blank"))
+        ggplot2::geom_point()
+      p_with_theme <- p + eval(parsed_all$theme)
+      testthat::expect_true(inherits(p_with_theme$theme, "theme"))
+      testthat::expect_true("axis.text" %in% names(p_with_theme$theme))
+      testthat::expect_true(inherits(p_with_theme$theme$axis.text, "element_blank"))
     }
   }
 )


### PR DESCRIPTION
Fixes https://github.com/insightsengineering/teal.widgets/issues/295

# Current fix

All 3 strategies are green (besides max which is fine)

https://github.com/insightsengineering/teal.widgets/actions/runs/15777310323

Solution: we needed to update `testthat` because the old version was dependent on old `digest` that could no longer be installed in our setup.


# Previous errors on main

```
Failed to build `digest` dependency
```

https://github.com/insightsengineering/teal.widgets/actions/runs/15659252962/job/44114591501#step:9:458

`digest` is a part of `testthat`.

