### PR TITLE
Set plot_with_settings width limits just once

### DIFF
--- a/R/plot_with_settings.R
+++ b/R/plot_with_settings.R
@@ -303,13 +303,6 @@ plot_with_settings_srv <- function(id,
         once = TRUE,
         ignoreNULL = TRUE
       )
-
-      observeEvent(delayed_flex_width(), {
-        if (delayed_flex_width() > 0 && !isFALSE(input$width_resize_switch)) {
-          default_slider_width(delayed_flex_width() * c(1, 0.5, 2.8))
-          updateSliderInput(session, inputId = "width", value = delayed_flex_width())
-        }
-      })
     }
 
     plot_type <- reactive({
@@ -364,7 +357,7 @@ plot_with_settings_srv <- function(id,
     })
 
     observeEvent(input$width_resize_switch | delayed_flex_width(), {
-      if (length(input$width_resize_switch) && input$width_resize_switch) {
+      if (!isFALSE(input$width_resize_switch)) {
         shinyjs::disable("width")
         updateSliderInput(session, inputId = "width", value = delayed_flex_width())
       } else {


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #301 

The width of the plot was modified by multiple observers when NULL was provided to the widget
By removing the second observer we get the desired/expected behavior: Only initially the size is set then it remains whatever the user choses even if the plot is expanded. 
See the issue for steps to check that the issue is fixed.

<details><summary>App</summary>
<p>

```r
devtools::load_all()
library(teal.modules.general)
options(
  shiny.useragg = FALSE,
  teal.ggplot2_args = teal.widgets::ggplot2_args(labs = list(caption = "NEST PROJECT"))
)

## Data reproducible code ----
data <- teal_data()
data <- within(data, {
  library(random.cdisc.data)
  ADSL <- radsl(seed = 1)
})

join_keys(data) <- default_cdisc_join_keys[names(data)]

## Reusable Configuration For Modules
ADSL <- data[["ADSL"]]


adsl_extracted_num <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL),
    selected = "AGE",
    multiple = FALSE,
    fixed = FALSE
  )
)
adsl_extracted_num2 <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL),
    selected = "BMRKR1",
    multiple = FALSE,
    fixed = FALSE
  )
)
adsl_extracted_fct <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL),
    selected = "ARMCD",
    multiple = FALSE,
    fixed = FALSE
  )
)
fact_vars_adsl <- names(Filter(isTRUE, sapply(ADSL, is.factor)))
adsl_extracted_fct2 <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL, subset = fact_vars_adsl),
    selected = "STRATA2",
    multiple = FALSE,
    fixed = FALSE
  )
)
adsl_extracted_fct3 <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL),
    selected = "ARMCD",
    multiple = TRUE,
    fixed = FALSE
  )
)
numeric_vars_adsl <- names(Filter(isTRUE, sapply(ADSL, is.numeric)))
adsl_extracted_numeric <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL, subset = numeric_vars_adsl),
    selected = "BMRKR1",
    multiple = FALSE,
    fixed = FALSE
  )
)
adsl_extracted_factors <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL, subset = fact_vars_adsl),
    selected = NULL,
    multiple = FALSE,
    fixed = FALSE
  )
)

adsl_extracted_multi <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL),
    selected = c("AGE", "BMRKR1"),
    multiple = TRUE,
    fixed = FALSE
  )
)
app <- init(
  data = data,
  filter = teal_slices(
    count_type = "all",
    teal_slice(dataname = "ADSL", varname = "SEX"),
    teal_slice(dataname = "ADSL", varname = "AGE")
  ),
  modules = modules(
    tm_g_scatterplot(
      "Scatterplot",
      x = adsl_extracted_num,
      y = adsl_extracted_num2,
      row_facet = adsl_extracted_factors,
      col_facet = adsl_extracted_factors,
      color_by = adsl_extracted_factors,
      size = 3, alpha = 1,
      plot_height = c(600L, 200L, 2000L)
    )
  )
) 
shinyApp(app$ui, app$server)

```

</p>
</details> 
