### PR TITLE
fix warning partial argument match

### DIFF
--- a/R/verbatim_popup.R
+++ b/R/verbatim_popup.R
@@ -6,7 +6,7 @@ verbatim_popup_deps <- function() {
     version = utils::packageVersion("teal.widgets"),
     package = "teal.widgets",
     src = "verbatim-popup",
-    style = "verbatim-popup.css",
+    stylesheet = "verbatim-popup.css",
     script = "verbatim-popup.js"
   )
 }


### PR DESCRIPTION
Fixes the partial argument match warning message from integration test.

<details>

<summary>Log</summary>

```r
══ Warnings ════════════════════════════════════════════════════════════════════
  ── Warning ('test-verbatim_popup_ui.R:27:3'): verbatim_popup_ui returns `shiny.tag.list` ──
  partial argument match of 'style' to 'stylesheet'
  Backtrace:
      ▆
   1. ├─testthat::expect_s3_class(verbatim_popup_ui("STH", "STH2"), "shiny.tag.list") at test-verbatim_popup_ui.R:27:3
   2. │ └─testthat::quasi_label(enquo(object), arg = "object")
   3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
   4. └─teal.widgets::verbatim_popup_ui("STH", "STH2")
   5.   ├─shiny::tagList(...)
   6.   │ └─rlang::dots_list(...)
   7.   └─teal.widgets:::verbatim_popup_deps()
  ── Warning ('test-verbatim_popup_ui.R:38:5'): e2e: teal.widgets::verbatim_popup is initialized with a button that opens a modal with a verbatim text ──
  partial argument match of 'style' to 'stylesheet'
  Backtrace:
       ▆
    1. ├─shinytest2::AppDriver$new(...) at test-verbatim_popup_ui.R:38:5
    2. │ └─shinytest2 (local) initialize(...)
    3. │   └─shinytest2:::app_initialize(...)
    4. │     ├─base::withCallingHandlers(...)
    5. │     └─shinytest2:::app_initialize_(self, private, ..., view = view)
    6. │       └─shiny::is.shiny.appobj(app_dir)
    7. └─teal.widgets (local) app_driver_vpu(...)
    8.   ├─shiny::shinyApp(...) at test-verbatim_popup_ui.R:8:3
    9.   │ └─shiny:::uiHttpHandler(ui, uiPattern)
   10.   │   └─base::force(ui)
   11.   ├─bslib::page_fluid(verbatim_popup_ui(id = "verbatim_popup", button_label = button_label))
   12.   │ ├─bslib:::as_page(...)
   13.   │ └─shiny::fluidPage(...)
   14.   │   ├─shiny::bootstrapPage(...)
   15.   │   │ └─rlang::list2(...)
   16.   │   └─htmltools::div(class = "container-fluid", ...)
   17.   │     └─rlang::dots_list(...)
   18.   └─teal.widgets::verbatim_popup_ui(id = "verbatim_popup", button_label = button_label)
   19.     ├─shiny::tagList(...)
   20.     │ └─rlang::dots_list(...)
   21.     └─teal.widgets:::verbatim_popup_deps()
  ── Warning ('test-verbatim_popup.R:91:3'): verbatim_popup_ui returns a tag list ──
  partial argument match of 'style' to 'stylesheet'
  Backtrace:
      ▆
   1. ├─testthat::expect_true(...) at test-verbatim_popup.R:91:3
   2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
   3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
   4. ├─base::inherits(...)
   5. └─teal.widgets::verbatim_popup_ui(id = "test_id", button_label = "Test button label")
   6.   ├─shiny::tagList(...)
   7.   │ └─rlang::dots_list(...)
   8.   └─teal.widgets:::verbatim_popup_deps()
  ── Warning ('test-verbatim_popup.R:97:3'): verbatim_popup_ui with type not equal to 'button' or 'link' throws error ──
  partial argument match of 'style' to 'stylesheet'
  Backtrace:
      ▆
   1. ├─testthat::expect_error(...) at test-verbatim_popup.R:97:3
   2. │ └─testthat:::quasi_capture(...)
   3. │   ├─testthat (local) .capture(...)
   4. │   │ └─base::withCallingHandlers(...)
   5. │   └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
   6. └─teal.widgets::verbatim_popup_ui(...)
   7.   ├─shiny::tagList(...)
   8.   │ └─rlang::dots_list(...)
   9.   └─teal.widgets:::verbatim_popup_deps()
  ── Warning ('test-verbatim_popup.R:104:3'): verbatim_popup_ui with type 'button' produces a button ──
  partial argument match of 'style' to 'stylesheet'
  Backtrace:
      ▆
   1. └─teal.widgets::verbatim_popup_ui(...) at test-verbatim_popup.R:104:3
   2.   ├─shiny::tagList(...)
   3.   │ └─rlang::dots_list(...)
   4.   └─teal.widgets:::verbatim_popup_deps()
  ── Warning ('test-verbatim_popup.R:109:3'): verbatim_popup_ui with type 'link' produces a button with a class link ──
  partial argument match of 'style' to 'stylesheet'
  Backtrace:
      ▆
   1. └─teal.widgets::verbatim_popup_ui(...) at test-verbatim_popup.R:109:3
   2.   ├─shiny::tagList(...)
   3.   │ └─rlang::dots_list(...)
   4.   └─teal.widgets:::verbatim_popup_deps()
```

</details>
