### PR TITLE
POC: Checking gtsummary works well with widgets for tables 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
     styler (>= 1.2.0)
 Suggests:
     DT,
+    gt (>= 1.0.0),
     knitr (>= 1.42),
     lattice (>= 0.18-4),
     magrittr (>= 1.5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     styler (>= 1.2.0)
 Suggests:
     DT,
-    gt (>= 1.0.0),
+    gtsummary (>= 2.4.0),
     knitr (>= 1.42),
     lattice (>= 0.18-4),
     magrittr (>= 1.5),

--- a/R/table_with_settings.R
+++ b/R/table_with_settings.R
@@ -111,8 +111,8 @@ table_with_settings_srv <- function(id, table_r, show_hide_signal = reactive(TRU
       }
     })
 
-    output$table_out_main <- output$table_out_modal <- renderUI({
-      rtables::as_html(table_r())
+    output$table_out_main <- output$table_out_modal <- gt::render_gt({
+      gtsummary::as_gt(table_r())
     })
 
     type_download_srv_table(


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Part of https://github.com/insightsengineering/teal.modules.clinical/pull/1420

This PR makes `table_with_settings_srv` work well for gtsummary tables so that they can be expanded in a modal.

TODO:
- [ ] The download formats doesn't work with: `Error in : unable to find an inherited method for function 'matrix_form' for signature 'obj = "tbl_summary"'`. The function `type_download_srv_table` should be updated too.
- [ ] Make `table_with_settings_srv` compatible with the previous output format: rtables
