### PR TITLE
change timeout for plot_with_settings_ui

### DIFF
--- a/tests/testthat/test-plot_with_settings_ui.R
+++ b/tests/testthat/test-plot_with_settings_ui.R
@@ -46,6 +46,7 @@ app_driver_pws <- function() {
   )
 }
 
+longer_timeout <- 80000
 
 # JS code to click the resize button popup.
 # nolint start
@@ -112,7 +113,7 @@ testthat::test_that(
       name = "pws",
       variant = "app_driver_pws_ui"
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     # Check if there is an image.
     testthat::expect_true(is_visible("#plot_with_settings-plot_main > img", app_driver))
@@ -134,10 +135,10 @@ testthat::test_that(
       name = "pws",
       variant = "app_driver_pws_ui"
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     testthat::expect_equal(
       app_driver$get_text("#plot_with_settings-downbutton-file_format-label"),
@@ -196,7 +197,7 @@ testthat::test_that(
       height = 1000,
       width = 1000
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
     app_driver$get_text(paste0(
       "#plot_with_settings-plot-with-settings > div > div > ",
       "div.teal-widgets.settings-buttons > bslib-tooltip.resize-button > div:nth-child(1)"
@@ -207,7 +208,7 @@ testthat::test_that(
     app_driver$set_inputs(`plot_with_settings-expbut` = TRUE)
 
     # Expand the plot and evaluate the output
-    app_driver$run_js(click_expand_popup, timeout = default_idle_timeout)
+    app_driver$run_js(click_expand_popup, timeout = longer_timeout)
     testthat::expect_true(is_visible("#bslib-full-screen-overlay", app_driver))
 
     # Resize button
@@ -234,10 +235,10 @@ testthat::test_that(
       name = "pws",
       variant = "app_driver_pws_ui"
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
     testthat::expect_true(is_visible("#plot_with_settings-plot_main > img", app_driver))
 
     testthat::expect_equal(
@@ -274,14 +275,14 @@ testthat::test_that(
       height = 1000,
       width = 1000
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     testthat::expect_false(is_visible("#plot_with_settings-slider_ui", app_driver))
 
     # nolint start
     app_driver$run_js(click_resize_popup)
     # nolint end
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
 
     testthat::expect_identical(
@@ -317,7 +318,7 @@ testthat::test_that(
       name = "pws",
       variant = "app_driver_pws_ui"
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     app_driver$set_inputs(`plot_with_settings-height` = 1000)
     app_driver$set_inputs(`plot_with_settings-width_resize_switch` = 350)
@@ -339,10 +340,10 @@ testthat::test_that(
       name = "pws",
       variant = "app_driver_pws_ui"
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle(timeout = longer_timeout)
 
     filename <- app_driver$get_download("plot_with_settings-downbutton-data_download")
     testthat::expect_match(filename, "png$", fixed = FALSE)
@@ -360,10 +361,10 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
     height = 1000,
     width = 1000
   )
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   app_driver$run_js(click_expand_popup)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   plot_before <- get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "src")
   values <- app_driver$get_values()
@@ -377,11 +378,11 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
     400L
   )
   app_driver$run_js(click_resize_popup)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   app_driver$set_inputs(`plot_with_settings-height` = 1000)
   app_driver$set_inputs(`plot_with_settings-width` = 350)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
   values_resized <- app_driver$get_values()
 
   testthat::expect_equal(
@@ -411,13 +412,13 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
     name = "pws",
     variant = "app_driver_pws_ui"
   )
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   app_driver$run_js(click_expand_popup)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   app_driver$run_js(click_download_popup)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   filename <- app_driver$get_download("plot_with_settings-downbutton-data_download")
   testthat::expect_match(filename, "png$", fixed = FALSE)
@@ -432,10 +433,10 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: main image can be res
     name = "pws",
     variant = "app_driver_pws_ui"
   )
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   app_driver$run_js(click_resize_popup)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   plot_before <- get_active_module_pws_output(app_driver, pws = "plot_main", attr = "src")
 
@@ -476,12 +477,12 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: scrollbar appears whe
     name = "pws",
     variant = "app_driver_pws_ui"
   )
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   app_driver$run_js(click_expand_popup)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
   app_driver$run_js(click_resize_popup)
-  app_driver$wait_for_idle(timeout = default_idle_timeout)
+  app_driver$wait_for_idle(timeout = longer_timeout)
 
   app_driver$set_inputs(`plot_with_settings-height` = 10000)
   app_driver$set_inputs(`plot_with_settings-width` = 350)


### PR DESCRIPTION
Logs 

- https://nest.pages.roche.com/-/automation/systems-integration-tests/-/jobs/115909296/artifacts/public/logs/check-teal.widgets.html

Part of

- https://github.com/insightsengineering/coredev-tasks/issues/687

Issue tries to fix

- plot_with_settings

```
  ══ Skipped tests (1) ═══════════════════════════════════════════════════════════
  • {whitr} is not installed (1): 'test-optionalSliderInputValMinMax_ui.R:38:3'
  
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Error ('test-plot_with_settings_ui.R:270:5'): e2e: teal.widgets::plot_with_settings: the click on the resize button opens a dropdown menu
    plot height, plot width, plot, download dropdown and dismiss button ──
  Error in `app_initialize(self, private, app_dir = app_dir, ..., load_timeout = load_timeout, timeout = timeout, wait = wait, expect_values_screenshot_args = expect_values_screenshot_args, screenshot_args = screenshot_args, check_names = check_names, name = name, variant = variant, view = view, height = height, width = width, seed = seed, clean_logs = clean_logs, shiny_args = shiny_args, render_args = render_args, options = options)`: Shiny app did not become stable in 15000ms.
  Message: An error occurred while waiting for Shiny to be stable
  Caused by error in `app_wait_for_idle()`:
  ! An error occurred while waiting for Shiny to be stable
  
  
  i You can inspect the failed AppDriver object via `rlang::last_error()$app`
  i AppDriver logs:
  {shinytest2} R  info   03:26:40.20 Start AppDriver initialization
  {shinytest2} R  info   03:26:40.38 Starting Shiny app
  {shinytest2} R  info   03:26:41.63 Creating new ChromoteSession
  {shinytest2} R  info   03:26:41.69 Setting window size: 1000x1000
  {shinytest2} R  info   03:26:41.69 Setting window size to `1000`x`1000`
  {shinytest2} R  info   03:26:41.69 Navigating to Shiny app
  {shinytest2} R  info   03:26:41.71 Injecting shiny-tracer.js
  {chromote}   JS info   03:26:41.81 shinytest2; jQuery not found
  {chromote}   JS info   03:26:41.81 shinytest2; Loaded
  {shinytest2} R  info   03:26:41.82 Waiting for Shiny to become ready
  {shinytest2} R  info   03:26:44.23 Waiting for Shiny to become idle for 200ms within 15000ms
  {shinytest2} R  info   03:26:44.36 Error while initializing AppDriver:
                                     Shiny app did not become stable in 15000ms.
                                     Message: An error occurred while waiting for Shiny to be stable
                                     Caused by error in `app_wait_for_idle()`:
                                     ! An error occurred while waiting for Shiny to be stable
  {shiny}      R  stderr ----------- Loading required package: shiny
  {shiny}      R  stderr ----------- Running application in test mode.
  {shiny}      R  stderr ----------- 
  {shiny}      R  stderr ----------- Listening on http://127.0.0.1:5338
  
  
  Caused by error in `app_initialize_()`:
  ! Shiny app did not become stable in 15000ms.
  Message: An error occurred while waiting for Shiny to be stable
  Caused by error in `app_wait_for_idle()`:
  ! An error occurred while waiting for Shiny to be stable
  Backtrace:
       ▆
    1. ├─shinytest2::AppDriver$new(...) at test-plot_with_settings_ui.R:270:5
    2. │ └─shinytest2 (local) initialize(...)
    3. │   └─shinytest2:::app_initialize(...)
    4. │     ├─base::withCallingHandlers(...)
    5. │     └─shinytest2:::app_initialize_(self, private, ..., view = view)
    6. │       ├─base::withCallingHandlers(...)
    7. │       └─self$wait_for_idle(duration = 200, timeout = private$load_timeout)
    8. │         └─shinytest2:::app_wait_for_idle(...)
    9. │           └─shinytest2:::app_abort(self, private, "An error occurred while waiting for Shiny to be stable")
   10. │             └─rlang::abort(..., app = self, call = call)
   11. │               └─rlang:::signal_abort(cnd, .file)
   12. │                 └─base::signalCondition(cnd)
   13. ├─shinytest2 (local) `<fn>`(`<rlng_rrr>`)
   14. │ └─shinytest2:::app_abort(...)
   15. │   └─rlang::abort(..., app = self, call = call)
   16. │     └─rlang:::signal_abort(cnd, .file)
   17. │       └─base::signalCondition(cnd)
   18. └─shinytest2 (local) `<fn>`(`<rlng_rrr>`)
   19.   └─shinytest2:::app_abort(...)
   20.     └─rlang::abort(..., app = self, call = call)
  ── Error ('test-plot_with_settings_ui.R:409:3'): e2e teal.widgets::plot_with_settings: expanded image can be downloaded ──
  Error in `app_initialize(self, private, app_dir = app_dir, ..., load_timeout = load_timeout, timeout = timeout, wait = wait, expect_values_screenshot_args = expect_values_screenshot_args, screenshot_args = screenshot_args, check_names = check_names, name = name, variant = variant, view = view, height = height, width = width, seed = seed, clean_logs = clean_logs, shiny_args = shiny_args, render_args = render_args, options = options)`: Shiny app did not become stable in 15000ms.
  Message: An error occurred while waiting for Shiny to be stable
  Caused by error in `app_wait_for_idle()`:
  ! An error occurred while waiting for Shiny to be stable
  
  
  i You can inspect the failed AppDriver object via `rlang::last_error()$app`
  i AppDriver logs:
  {shinytest2} R  info   03:27:25.73 Start AppDriver initialization
  {shinytest2} R  info   03:27:26.10 Starting Shiny app
  {shinytest2} R  info   03:27:28.21 Creating new ChromoteSession
  {shinytest2} R  info   03:27:28.34 Navigating to Shiny app
  {shinytest2} R  info   03:27:28.36 Injecting shiny-tracer.js
  {chromote}   JS info   03:27:28.40 shinytest2; jQuery not found
  {chromote}   JS info   03:27:28.41 shinytest2; Loaded
  {shinytest2} R  info   03:27:28.41 Waiting for Shiny to become ready
  {shinytest2} R  info   03:27:31.23 Waiting for Shiny to become idle for 200ms within 15000ms
  {shinytest2} R  info   03:27:31.32 Error while initializing AppDriver:
                                     Shiny app did not become stable in 15000ms.
                                     Message: An error occurred while waiting for Shiny to be stable
                                     Caused by error in `app_wait_for_idle()`:
                                     ! An error occurred while waiting for Shiny to be stable
  {shiny}      R  stderr ----------- Loading required package: shiny
  {shiny}      R  stderr ----------- Running application in test mode.
  {shiny}      R  stderr ----------- 
  {shiny}      R  stderr ----------- Listening on http://127.0.0.1:5932
  
  
  Caused by error in `app_initialize_()`:
  ! Shiny app did not become stable in 15000ms.
  Message: An error occurred while waiting for Shiny to be stable
  Caused by error in `app_wait_for_idle()`:
  ! An error occurred while waiting for Shiny to be stable
```