### PR TITLE
Unskip a test that was skipped due to a typo in package name

### DIFF
--- a/tests/testthat/test-optionalSliderInputValMinMax_ui.R
+++ b/tests/testthat/test-optionalSliderInputValMinMax_ui.R
@@ -35,7 +35,7 @@ testthat::test_that("we create label help for optionalSliderInputValMinMax", {
 })
 
 testthat::test_that("snapshot test for optionalSliderInput", {
-  testthat::skip_if_not_installed("whitr")
+  testthat::skip_if_not_installed("withr")
   withr::local_seed(1)
   testthat::expect_snapshot(as.character(optionalSliderInput("my slider", "my label", 0, 10, 2)))
 })


### PR DESCRIPTION
# Pull Request

There is not issue only for this PR, although is related to [this issue](https://github.com/orgs/insightsengineering/projects/39/views/16?pane=issue&itemId=137472345&issue=insightsengineering%7Ccoredev-tasks%7C687)

There was a test skipped because there was a typo in `withr` package name. Now no test should be skipped if all suggested packages are installed.


