### PR TITLE
Implements standard timeouts in shinytest2 with options

### DIFF
--- a/tests/testthat/_snaps/verbatim_popup_ui.md
+++ b/tests/testthat/_snaps/verbatim_popup_ui.md
@@ -3,5 +3,7 @@
     Code
       verbatim_popup_ui("STH", "STH2")
     Output
-      <button class="btn btn-default action-button teal-widgets-busy-disable button" id="STH-button" type="button">STH2</button>
+      <button class="btn btn-default action-button teal-widgets-busy-disable button" id="STH-button" type="button">
+        <span class="action-label">STH2</span>
+      </button>
 

--- a/tests/testthat/helpers-shinytest2.R
+++ b/tests/testthat/helpers-shinytest2.R
@@ -1,0 +1,8 @@
+withr::local_options(
+  list(
+    shinytest2.timeout = 30 * 1000,
+    shinytest2.load_timeout = 60 * 1000,
+    shinytest2.duration = 0.5 * 1000
+  ),
+  .local_envir = testthat::test_env()
+)

--- a/tests/testthat/helpers-testing-depth.R
+++ b/tests/testthat/helpers-testing-depth.R
@@ -47,5 +47,3 @@ skip_if_too_deep <- function(depth) { # nolintr
     testthat::skip(paste("testing depth", testing_depth, "is below current testing specification", depth))
   }
 }
-
-default_idle_timeout <- 20000

--- a/tests/testthat/helpers-utils.R
+++ b/tests/testthat/helpers-utils.R
@@ -18,7 +18,6 @@ is_draw <- function(plot_fun) {
   res
 }
 
-
 is_visible <- function(element, app_driver) {
   any(
     unlist(

--- a/tests/testthat/test-draggable_buckets.R
+++ b/tests/testthat/test-draggable_buckets.R
@@ -7,23 +7,25 @@ app_driver_db <- function(input_id, label, elements = character(), buckets) {
       buckets = buckets
     )
   )
-
-  shinytest2::AppDriver$new(
-    shiny::shinyApp(ui, function(input, output) {})
-  )
+  shiny::shinyApp(ui, function(input, output) {})
 }
 
 testthat::test_that(
   "e2e: teal.widgets::draggable_buckets: initializes without input",
   {
     skip_if_too_deep(5)
-    app_driver <- app_driver_db(
-      input_id = "id",
-      label = "Choices",
-      elements = c("a", "b"),
-      buckets = c("bucket1", "bucket2")
+    app_driver <- shinytest2::AppDriver$new(
+      app_driver_db(
+        input_id = "id",
+        label = "Choices",
+        elements = c("a", "b"),
+        buckets = c("bucket1", "bucket2")
+      ),
+      name = "db",
+      variant = "app_driver_db_ui",
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     testthat::expect_true(is_visible("#id.draggableBuckets.shiny-bound-input", app_driver))
     testthat::expect_identical(
       app_driver$get_value(input = "id"),
@@ -40,16 +42,21 @@ testthat::test_that(
   "e2e: teal.widgets::draggable_buckets: initializes with default inputs",
   {
     skip_if_too_deep(5)
-    app_driver <- app_driver_db(
-      input_id = "id",
-      label = "Choices",
-      elements = character(),
-      buckets = list(
-        "Ref" = "B: Placebo",
-        "Comp" = c("A: Drug X", "C: Combination")
-      )
+    app_driver <- shinytest2::AppDriver$new(
+      app_driver_db(
+        input_id = "id",
+        label = "Choices",
+        elements = character(),
+        buckets = list(
+          "Ref" = "B: Placebo",
+          "Comp" = c("A: Drug X", "C: Combination")
+        )
+      ),
+      name = "db",
+      variant = "app_driver_db_ui",
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     values <- app_driver$get_value(input = "id")
     testthat::expect_identical(
       app_driver$get_value(input = "id"),
@@ -66,16 +73,21 @@ testthat::test_that(
   "e2e: teal.widgets::draggable_buckets: moving elements between buckets updates input",
   {
     skip_if_too_deep(5)
-    app_driver <- app_driver_db(
-      input_id = "id",
-      label = "Choices",
-      elements = character(),
-      buckets = list(
-        "Ref" = "B: Placebo",
-        "Comp" = c("A: Drug X", "C: Combination")
-      )
+    app_driver <- shinytest2::AppDriver$new(
+      app_driver_db(
+        input_id = "id",
+        label = "Choices",
+        elements = character(),
+        buckets = list(
+          "Ref" = "B: Placebo",
+          "Comp" = c("A: Drug X", "C: Combination")
+        )
+      ),
+      name = "db",
+      variant = "app_driver_db_ui",
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     app_driver$run_js(
       "
       // Find the buckets
@@ -89,7 +101,7 @@ testthat::test_that(
       refBucket.appendChild(element);
       "
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     testthat::expect_identical(
       app_driver$get_value(input = "id")$Ref,
       list("B: Placebo", "A: Drug X")

--- a/tests/testthat/test-get_dt_rows_ui.R
+++ b/tests/testthat/test-get_dt_rows_ui.R
@@ -49,9 +49,10 @@ testthat::test_that(
     app_driver <- shinytest2::AppDriver$new(
       app_driver_gdr(),
       name = "gdr",
-      variant = "app_driver_gdr_ui"
+      variant = "app_driver_gdr_ui",
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     testthat::expect_true(is_visible("#my_table_module-data_table", app_driver))
 
     # Check initial value
@@ -61,7 +62,7 @@ testthat::test_that(
 
     # Change rows value
     app_driver$click(selector = "#show_25")
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
 
     # Check value again
     dt_state <- app_driver$get_values(input = "my_table_module-data_table_state")

--- a/tests/testthat/test-optionalSelectInput_ui.R
+++ b/tests/testthat/test-optionalSelectInput_ui.R
@@ -96,9 +96,10 @@ testthat::test_that(
     app_driver <- shinytest2::AppDriver$new(
       app_driver_osi(),
       name = "osi",
-      variant = "app_driver_osi_ui"
+      variant = "app_driver_osi_ui",
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     gv <- app_driver$get_values()
     output <- list(
       c1_out = "[1] \"A\" \"B\"", c2_out = "[1] \"A\"", c3_out = "NULL",

--- a/tests/testthat/test-optionalSliderInputValMinMax_ui.R
+++ b/tests/testthat/test-optionalSliderInputValMinMax_ui.R
@@ -17,9 +17,10 @@ testthat::test_that(
     app_driver <- shinytest2::AppDriver$new(
       app_driver_osivmm(),
       name = "osivmm",
-      variant = "app_driver_osivmm_ui"
+      variant = "app_driver_osivmm_ui",
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     testthat::expect_false(is_visible("#a1-label", app_driver))
     testthat::expect_true(is_visible("#a2-label", app_driver))
     app_driver$stop()

--- a/tests/testthat/test-plot_with_settings_ui.R
+++ b/tests/testthat/test-plot_with_settings_ui.R
@@ -1,3 +1,11 @@
+withr::local_options( # Set longer timeouts for slow tests
+  list(
+    shinytest2.timeout = 4 * 30 * 1000,
+    shinytest2.load_timeout = 4 * 60 * 1000,
+    shinytest2.duration = 2 * 0.5 * 1000
+  )
+)
+
 #' Plot with settings app
 #'
 #' @description Example plot with setting app for testing using \code{shinytest2}
@@ -45,8 +53,6 @@ app_driver_pws <- function() {
     }
   )
 }
-
-longer_timeout <- 80000
 
 # JS code to click the resize button popup.
 # nolint start
@@ -112,10 +118,9 @@ testthat::test_that(
       app_driver_pws(),
       name = "pws",
       variant = "app_driver_pws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     # Check if there is an image.
     testthat::expect_true(is_visible("#plot_with_settings-plot_main > img", app_driver))
@@ -136,13 +141,12 @@ testthat::test_that(
       app_driver_pws(),
       name = "pws",
       variant = "app_driver_pws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     testthat::expect_equal(
       app_driver$get_text("#plot_with_settings-downbutton-file_format-label"),
@@ -200,10 +204,9 @@ testthat::test_that(
       variant = "app_driver_pws_ui",
       height = 1000,
       width = 1000,
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
     app_driver$get_text(paste0(
       "#plot_with_settings-plot-with-settings > div > div > ",
       "div.teal-widgets.settings-buttons > bslib-tooltip.resize-button > div:nth-child(1)"
@@ -214,7 +217,7 @@ testthat::test_that(
     app_driver$set_inputs(`plot_with_settings-expbut` = TRUE)
 
     # Expand the plot and evaluate the output
-    app_driver$run_js(click_expand_popup, timeout = longer_timeout)
+    app_driver$run_js(click_expand_popup)
     testthat::expect_true(is_visible("#bslib-full-screen-overlay", app_driver))
 
     # Resize button
@@ -240,13 +243,12 @@ testthat::test_that(
       app_driver_pws(),
       name = "pws",
       variant = "app_driver_pws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
     testthat::expect_true(is_visible("#plot_with_settings-plot_main > img", app_driver))
 
     testthat::expect_equal(
@@ -282,15 +284,14 @@ testthat::test_that(
       variant = "app_driver_pws_ui",
       height = 1000,
       width = 1000,
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     testthat::expect_false(is_visible("#plot_with_settings-slider_ui", app_driver))
 
     app_driver$run_js(click_resize_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
 
     testthat::expect_identical(
@@ -325,12 +326,11 @@ testthat::test_that(
       app_driver_pws(),
       name = "pws",
       variant = "app_driver_pws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
     app_driver$run_js(click_resize_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
     app_driver$set_inputs(`plot_with_settings-height` = 1000)
     app_driver$set_inputs(`plot_with_settings-width_resize_switch` = 350)
 
@@ -350,13 +350,12 @@ testthat::test_that(
       app_driver_pws(),
       name = "pws",
       variant = "app_driver_pws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     filename <- app_driver$get_download("plot_with_settings-downbutton-data_download")
     testthat::expect_match(filename, "png$", fixed = FALSE)
@@ -373,13 +372,12 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
     variant = "app_driver_pws_ui",
     height = 1000,
     width = 1000,
-    timeout = 30000,
-    load_timeout = 100000
+    wait = FALSE
   )
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$run_js(click_expand_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   plot_before <- get_active_module_pws_output(app_driver, pws = "plot_modal", attr = "src")
   values <- app_driver$get_values()
@@ -393,11 +391,11 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
     400L
   )
   app_driver$run_js(click_resize_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$set_inputs(`plot_with_settings-height` = 1000)
   app_driver$set_inputs(`plot_with_settings-width` = 350)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
   values_resized <- app_driver$get_values()
 
   testthat::expect_equal(
@@ -426,16 +424,15 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: expanded image can be
     app_driver_pws(),
     name = "pws",
     variant = "app_driver_pws_ui",
-    timeout = 30000,
-    load_timeout = 100000
+    wait = FALSE
   )
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$run_js(click_expand_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$run_js(click_download_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   filename <- app_driver$get_download("plot_with_settings-downbutton-data_download")
   testthat::expect_match(filename, "png$", fixed = FALSE)
@@ -449,13 +446,12 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: main image can be res
     app_driver_pws(),
     name = "pws",
     variant = "app_driver_pws_ui",
-    timeout = 30000,
-    load_timeout = 100000
+    wait = FALSE
   )
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$run_js(click_resize_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   plot_before <- get_active_module_pws_output(app_driver, pws = "plot_main", attr = "src")
 
@@ -495,15 +491,14 @@ testthat::test_that("e2e teal.widgets::plot_with_settings: scrollbar appears whe
     app_driver_pws(),
     name = "pws",
     variant = "app_driver_pws_ui",
-    timeout = 30000,
-    load_timeout = 100000
+    wait = FALSE
   )
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$run_js(click_expand_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
   app_driver$run_js(click_resize_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$set_inputs(`plot_with_settings-height` = 10000)
   app_driver$set_inputs(`plot_with_settings-width` = 350)

--- a/tests/testthat/test-table_with_settings_ui.R
+++ b/tests/testthat/test-table_with_settings_ui.R
@@ -1,3 +1,11 @@
+withr::local_options( # Set longer timeouts for slow tests
+  list(
+    shinytest2.timeout = 4 * 30 * 1000,
+    shinytest2.load_timeout = 4 * 60 * 1000,
+    shinytest2.duration = 2 * 0.5 * 1000
+  )
+)
+
 #' Table with settings app
 #'
 #' @description Example table with setting app for testing using \code{shinytest2}
@@ -29,9 +37,6 @@ app_driver_tws <- function() {
     }
   )
 }
-
-longer_timeout <- 80000
-longer_duration <- 1000
 
 # nolint start
 # JS code to click the expand button popup.
@@ -70,14 +75,14 @@ testthat::test_that(
   "e2e: teal.widgets::table_with_settings is initialized with 2 buttons and a table",
   {
     skip_if_too_deep(5)
+
     app_driver <- shinytest2::AppDriver$new(
       app_driver_tws(),
       name = "tws",
       variant = "app_driver_tws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout * 4)
+    app_driver$wait_for_idle()
 
     # Check if there is an table.
     testthat::expect_true(is_visible("#table_with_settings-table_out_main > .rtables-container", app_driver))
@@ -98,17 +103,16 @@ testthat::test_that(
       app_driver_tws(),
       name = "tws",
       variant = "app_driver_tws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     testthat::expect_false(is_visible("#table_with_settings-downbutton-data_download", app_driver))
     testthat::expect_false(is_visible("#table_with_settings-downbutton-file_format", app_driver))
     testthat::expect_false(is_visible("#table_with_settings-downbutton-file_name", app_driver))
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     testthat::expect_equal(
       app_driver$get_text("#table_with_settings-downbutton-file_format-label"),
@@ -164,20 +168,19 @@ testthat::test_that(
       app_driver_tws(),
       name = "tws",
       variant = "app_driver_tws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     pagination_text <- app_driver$get_text(".paginate-ui")
     testthat::expect_match(pagination_text, "Paginate table:\n", fixed = TRUE)
     testthat::expect_match(pagination_text, "lines / page\n", fixed = TRUE)
 
     app_driver$click(selector = "input[value='.csv']")
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     testthat::expect_false(is_visible(".paginate-ui", app_driver))
 
@@ -193,16 +196,15 @@ testthat::test_that(
       app_driver_tws(),
       name = "tws",
       variant = "app_driver_tws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(duration = longer_duration, timeout = longer_timeout * 4)
+    app_driver$wait_for_idle()
 
     testthat::expect_false(is_visible("#table_with_settings-table_out_main", app_driver))
     testthat::expect_false(is_visible("#bslib-full-screen-overlay", app_driver))
 
     app_driver$run_js(click_expand_popup)
-    app_driver$wait_for_idle(duration = longer_duration, timeout = longer_timeout * 4)
+    app_driver$wait_for_idle()
 
     table_content <- app_driver$get_text("#table_with_settings-table_out_main")
 
@@ -212,7 +214,7 @@ testthat::test_that(
     # Close modal.
     app_driver$run_js("document.querySelector('#bslib-full-screen-overlay .bslib-full-screen-exit').click();")
 
-    app_driver$wait_for_idle(duration = longer_duration, timeout = longer_timeout * 4)
+    app_driver$wait_for_idle()
     testthat::expect_false(is_visible("#bslib-full-screen-overlay", app_driver))
 
     # Review the main table content.
@@ -232,15 +234,14 @@ testthat::test_that(
       app_driver_tws(),
       name = "tws",
       variant = "app_driver_tws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     app_driver$run_js(click_expand_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     testthat::expect_equal(
       app_driver$get_text("#table_with_settings-downbutton-file_format-label"),
@@ -300,15 +301,14 @@ testthat::test_that(
       app_driver_tws(),
       name = "tws",
       variant = "app_driver_tws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     app_driver$run_js(click_expand_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(timeout = longer_timeout)
+    app_driver$wait_for_idle()
 
     pagination_text <- app_driver$get_text(".paginate-ui")
     testthat::expect_match(pagination_text, "Paginate table:\n", fixed = TRUE)
@@ -326,13 +326,12 @@ testthat::test_that(
       app_driver_tws(),
       name = "tws",
       variant = "app_driver_tws_ui",
-      timeout = 30000,
-      load_timeout = 100000
+      wait = FALSE
     )
-    app_driver$wait_for_idle(duration = longer_duration, timeout = longer_timeout * 4)
+    app_driver$wait_for_idle()
 
     app_driver$run_js(click_download_popup)
-    app_driver$wait_for_idle(duration = longer_duration, timeout = longer_timeout * 4)
+    app_driver$wait_for_idle()
 
     filename <- app_driver$get_download("table_with_settings-downbutton-data_download")
     testthat::expect_match(filename, "txt$", fixed = FALSE)
@@ -350,16 +349,15 @@ testthat::test_that("e2e teal.widgets::table_with_settings: expanded table can b
     app_driver_tws(),
     name = "tws",
     variant = "app_driver_tws_ui",
-    timeout = 30000,
-    load_timeout = 100000
+    wait = FALSE
   )
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$run_js(click_expand_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   app_driver$run_js(click_download_popup)
-  app_driver$wait_for_idle(timeout = longer_timeout)
+  app_driver$wait_for_idle()
 
   filename <- app_driver$get_download("table_with_settings-downbutton-data_download")
   testthat::expect_match(filename, "txt$", fixed = FALSE)

--- a/tests/testthat/test-verbatim_popup_ui.R
+++ b/tests/testthat/test-verbatim_popup_ui.R
@@ -42,44 +42,44 @@ testthat::test_that(
         title = modal_title
       ),
       name = "vpu",
-      variant = "app_driver_vpu_ui"
+      variant = "app_driver_vpu_ui",
+      wait = FALSE
     )
-
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
 
     popup_button_element <- "#verbatim_popup-button"
     testthat::expect_equal(
-      app_driver$get_text(popup_button_element),
+      trimws(app_driver$get_text(popup_button_element)),
       ui_popup_button_label
     )
 
     # Click the button.
     app_driver$click(selector = popup_button_element)
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
 
     # Verify the content of the popped modal is as expected.
     testthat::expect_equal(
-      app_driver$get_text(".modal-title"),
+      trimws(app_driver$get_text(".modal-title")),
       modal_title
     )
 
     testthat::expect_equal(
-      app_driver$get_text("#verbatim_popup-copy_button1"),
+      trimws(app_driver$get_text("#verbatim_popup-copy_button1")),
       "Copy to Clipboard"
     )
     testthat::expect_equal(
-      app_driver$get_text(".modal-footer button:nth-of-type(1)"),
+      trimws(app_driver$get_text(".modal-footer button:nth-of-type(1)")),
       "Dismiss"
     )
 
     testthat::expect_equal(
-      app_driver$get_text("#verbatim_popup-verbatim_content"),
+      trimws(app_driver$get_text("#verbatim_popup-verbatim_content")),
       verbatim_content_text
     )
 
     # Modal is closed, once the button is clicked.
     app_driver$click(selector = ".modal-body button[data-dismiss='modal']")
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
     testthat::expect_null(app_driver$get_html("#shiny-modal-wrapper"))
 
     app_driver$stop()
@@ -122,7 +122,7 @@ testthat::test_that(
       name = "verbatim_popup_disabled",
       variant = "app_driver_vpu_disabled"
     )
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
 
     popup_button_selector <- "#verbatim_popup-button"
 
@@ -132,7 +132,7 @@ testthat::test_that(
 
     # Toggle to disabled state
     app_driver$click("toggle_disable")
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
 
     # Button should now be disabled
     button_html <- app_driver$get_html(popup_button_selector)
@@ -140,7 +140,7 @@ testthat::test_that(
 
     # Toggle back to enabled state
     app_driver$click("toggle_disable")
-    app_driver$wait_for_idle(timeout = default_idle_timeout)
+    app_driver$wait_for_idle()
 
     # Button should be enabled again
     button_html <- app_driver$get_html(popup_button_selector)


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

- Part of https://github.com/insightsengineering/coredev-tasks/issues/687 (issue needs to be closed manually after verification)

### Changes description

- Setup standard method of setting timeout (using R options)
- Stop waiting for idle during initialization as we are already doing it after (this should allow for better run of tests in slower machines)
