### PR TITLE
Fix output assignment for table rendering

### DIFF
--- a/R/table_with_settings.R
+++ b/R/table_with_settings.R
@@ -111,7 +111,7 @@ table_with_settings_srv <- function(id, table_r, show_hide_signal = reactive(TRU
       }
     })
 
-    output$table_out_main <- output$table_out_modal <- renderUI({
+    output$table_out_main <- renderUI({
       rtables::as_html(table_r())
     })
 


### PR DESCRIPTION
Looks like this output is not used anywhere
It is used only in this PR https://github.com/insightsengineering/teal.widgets/pull/337
but I can always change `table_out_modal` to `table_out_main`